### PR TITLE
fix(auth): secure reset-password flow — lookup by email, crypto tokens

### DIFF
--- a/backend/AUTHENTICATION_README.md
+++ b/backend/AUTHENTICATION_README.md
@@ -86,6 +86,7 @@ POST /auth/reset-password
 Content-Type: application/json
 
 {
+  "email": "user@example.com",
   "token": "reset-token-string",
   "newPassword": "newpassword123"
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -80,6 +80,7 @@ export class AuthService {
   async resetPassword(resetPasswordDto: ResetPasswordDto) {
     try {
       await this.userService.resetPassword(
+        resetPasswordDto.email,
         resetPasswordDto.token,
         resetPasswordDto.newPassword,
       );

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,6 +1,9 @@
-import { IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class ResetPasswordDto {
+  @IsEmail()
+  email: string;
+
   @IsString()
   token: string;
 


### PR DESCRIPTION


## Secure password reset flow

### Problem
- Reset password loaded **all users** with a non-expired `resetTokenExpires`, then iterated with `bcrypt.compare` to find a match → full table scan that gets slower as users grow and a possible timing side-channel.
- Reset tokens were generated with `Math.random()`, which is not cryptographically secure.

### Solution
- **Lookup by email:** `POST /auth/reset-password` now requires `email` in the body. The backend finds one user by `email` and non-expired `resetTokenExpires`, then verifies the token only for that user. No table scan.
- **Secure token generation:** `generateResetToken()` now uses `crypto.randomBytes(32).toString('hex')` instead of `Math.random()`.

### Changes
- **ResetPasswordDto:** Added `email` with `@IsEmail()`.
- **UserService.resetPassword:** Signature is `(email, token, newPassword)`; uses `findOne` by `email` + `resetTokenExpires > now`, then a single `bcrypt.compare`.
- **UserService.generateResetToken:** Uses Node `crypto.randomBytes(32).toString('hex')`.
- **AuthService.resetPassword:** Passes `resetPasswordDto.email` into `userService.resetPassword`.
- **Docs:** `AUTHENTICATION_README.md` updated so the reset-password example includes `email`.

### Outcome
- O(1) lookup by email; performance no longer depends on how many users have pending reset tokens.
- Cryptographically secure reset tokens.
- No full table scan; reduced timing-attack surface.

### Breaking change
- **API:** `POST /auth/reset-password` request body must now include `email` along with `token` and `newPassword`. Clients (e.g. any reset-password form) must be updated to send `email`.

### Closes: #161 