### PR TITLE
fix(courses): remove duplicate GET /courses, add pagination via Pagination

### DIFF
--- a/backend/src/common/services/pagination.service.ts
+++ b/backend/src/common/services/pagination.service.ts
@@ -1,4 +1,60 @@
 import { Injectable } from '@nestjs/common';
+import {
+  Repository,
+  FindOptionsWhere,
+  FindOptionsOrder,
+  ObjectLiteral,
+} from 'typeorm';
+
+export interface PaginateOptions<T> {
+  page: number;
+  limit: number;
+  where?: FindOptionsWhere<T>;
+  order?: FindOptionsOrder<T>;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
 
 @Injectable()
-export class PaginationService {}
+export class PaginationService {
+  /**
+   * Paginate a TypeORM repository query.
+   * @param repo Repository instance
+   * @param options page (1-based), limit, optional where and order
+   * @returns Paginated result with data, total, page, limit, totalPages
+   */
+  async paginate<T extends ObjectLiteral>(
+    repo: Repository<T>,
+    options: PaginateOptions<T>,
+  ): Promise<PaginatedResult<T>> {
+    const { page, limit, where, order } = options;
+    const skip = (Math.max(1, page) - 1) * limit;
+    const take = Math.max(1, Math.min(limit, 100));
+
+    const [data, total] = await Promise.all([
+      repo.find({
+        where,
+        order,
+        skip,
+        take,
+      }),
+      repo.count({ where }),
+    ]);
+
+    const totalPages = Math.ceil(total / take);
+
+    return {
+      data,
+      total,
+      page: Math.max(1, page),
+      limit: take,
+      totalPages,
+    };
+  }
+}

--- a/backend/src/courses/courses.controller.ts
+++ b/backend/src/courses/courses.controller.ts
@@ -7,7 +7,7 @@ import {
   Patch,
   UseGuards,
   Req,
-  // Query,
+  Query,
 } from '@nestjs/common';
 
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
@@ -38,8 +38,11 @@ export class CoursesController {
   }
 
   @Get()
-  async findAll(): Promise<CourseResponseDto[]> {
-    return this.coursesService.findAll();
+  async findAll(
+    @Query('page') page: string = '1',
+    @Query('limit') limit: string = '10',
+  ) {
+    return this.coursesService.findAll(Number(page) || 1, Number(limit) || 10);
   }
 
   @Get('registered')
@@ -73,11 +76,4 @@ export class CoursesController {
     return { message: 'Successfully enrolled in course' };
   }
 
-  // @Get()
-  // async getCourses(@Query('page') page = '1', @Query('limit') limit = '10') {
-  //   return this.paginationService.findAll({
-  //     page: Number(page),
-  //     limit: Number(limit),
-  //   });
-  // }
 }

--- a/backend/src/courses/courses.module.ts
+++ b/backend/src/courses/courses.module.ts
@@ -5,11 +5,12 @@ import { CoursesController } from './courses.controller';
 import { CoursesService } from './courses.service';
 import { CourseRegistration } from './entities/course-registration.entity';
 import { AuthModule } from '../auth/auth.module';
+import { PaginationService } from '../common/services/pagination.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Course, CourseRegistration]), AuthModule],
   controllers: [CoursesController],
-  providers: [CoursesService],
+  providers: [CoursesService, PaginationService],
   exports: [CoursesService],
 })
 export class CoursesModule {}

--- a/backend/src/courses/courses.service.spec.ts
+++ b/backend/src/courses/courses.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { CoursesService } from './courses.service';
 import { Course } from './entities/course.entity';
 import { CourseRegistration } from './entities/course-registration.entity';
+import { PaginationService } from 'src/common/services/pagination.service';
 
 const mockRepo = () => ({ findOne: jest.fn(), find: jest.fn(), create: jest.fn(), save: jest.fn() });
 
@@ -15,6 +16,7 @@ describe('CoursesService', () => {
         CoursesService,
         { provide: getRepositoryToken(Course), useValue: mockRepo() },
         { provide: getRepositoryToken(CourseRegistration), useValue: mockRepo() },
+        { provide: PaginationService, useValue: { paginate: jest.fn().mockResolvedValue({ data: [], total: 0, page: 1, limit: 10, totalPages: 0 }) } },
       ],
     }).compile();
 

--- a/backend/src/courses/courses.service.ts
+++ b/backend/src/courses/courses.service.ts
@@ -6,6 +6,10 @@ import { CourseResponseDto } from './dto/course-response.dto';
 import { CreateCourseDto } from './dto/create-course.dto';
 import { UpdateCourseDto } from './dto/update-course.dto';
 import { Course } from './entities/course.entity';
+import {
+  PaginationService,
+  PaginatedResult,
+} from 'src/common/services/pagination.service';
 
 @Injectable()
 export class CoursesService {
@@ -14,6 +18,7 @@ export class CoursesService {
     private courseRepository: Repository<Course>,
     @InjectRepository(CourseRegistration)
     private courseRegistrationRepository: Repository<CourseRegistration>,
+    private readonly paginationService: PaginationService,
   ) {}
 
   async create(createCourseDto: CreateCourseDto): Promise<CourseResponseDto> {
@@ -22,12 +27,20 @@ export class CoursesService {
     return new CourseResponseDto(savedCourse);
   }
 
-  async findAll(): Promise<CourseResponseDto[]> {
-    const courses = await this.courseRepository.find({
+  async findAll(
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<PaginatedResult<CourseResponseDto>> {
+    const result = await this.paginationService.paginate<Course>(this.courseRepository, {
+      page,
+      limit,
       where: { published: true },
       order: { createdAt: 'DESC' },
     });
-    return courses.map((course) => new CourseResponseDto(course));
+    return {
+      ...result,
+      data: result.data.map((course) => new CourseResponseDto(course)),
+    };
   }
 
   async findOne(id: string): Promise<CourseResponseDto> {


### PR DESCRIPTION
Closes #157 

This PR resolves the duplicate @Get() route definition in CoursesController, where two methods were mapped to GET /courses. Since NestJS only registers the first matching route, the second handler (getCourses) was never executed and relied on the previously broken PaginationService.

 Changes Implemented

✅ Removed the duplicate getCourses() method entirely

✅ Consolidated pagination logic into the existing findAll() handler

✅ Added @Query('page') and @Query('limit') parameters to findAll()

