### PR TITLE
FIX: Return correct HTTP status codes for auth error scenarios

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -15,21 +15,17 @@ export class AuthService {
   ) {}
 
   async register(registerDto: RegisterDto) {
-    try {
-      const user = await this.userService.create(registerDto);
-      const token = this.generateToken(user);
+    const user = await this.userService.create(registerDto);
+    const token = this.generateToken(user);
 
-      return {
-        user: {
-          id: user.id,
-          email: user.email,
-          role: user.role,
-        },
-        token,
-      };
-    } catch (error) {
-      throw new UnauthorizedException(error.message);
-    }
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+      },
+      token,
+    };
   }
 
   async login(loginDto: LoginDto) {
@@ -61,36 +57,28 @@ export class AuthService {
   }
 
   async forgotPassword(forgotPasswordDto: ForgotPasswordDto) {
-    try {
-      const resetToken = await this.userService.createResetToken(
-        forgotPasswordDto.email,
-      );
+    const resetToken = await this.userService.createResetToken(
+      forgotPasswordDto.email,
+    );
 
-      // In a real application, you would send an email here
-      // For now, we'll just return the token (in production, never do this)
-      return {
-        message: 'Password reset link sent to your email',
-        resetToken, // Only for development/testing
-      };
-    } catch (error) {
-      throw new UnauthorizedException(error.message);
-    }
+    // In a real application, you would send an email here
+    // For now, we'll just return the token (in production, never do this)
+    return {
+      message: 'Password reset link sent to your email',
+      resetToken, // Only for development/testing
+    };
   }
 
   async resetPassword(resetPasswordDto: ResetPasswordDto) {
-    try {
-      await this.userService.resetPassword(
-        resetPasswordDto.email,
-        resetPasswordDto.token,
-        resetPasswordDto.newPassword,
-      );
+    await this.userService.resetPassword(
+      resetPasswordDto.email,
+      resetPasswordDto.token,
+      resetPasswordDto.newPassword,
+    );
 
-      return {
-        message: 'Password reset successfully',
-      };
-    } catch (error) {
-      throw new UnauthorizedException(error.message);
-    }
+    return {
+      message: 'Password reset successfully',
+    };
   }
 
   private generateToken(user: any) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import * as crypto from 'crypto';
@@ -20,7 +25,7 @@ export class UserService {
     });
 
     if (existingUser) {
-      throw new Error('User with this email already exists');
+      throw new ConflictException('An account with this email already exists');
     }
 
     const hashedPassword = await bcrypt.hash(userData.password, 10);
@@ -56,7 +61,7 @@ export class UserService {
   async createResetToken(email: string): Promise<string> {
     const user = await this.findByEmail(email);
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundException('User not found');
     }
 
     const resetToken = this.generateResetToken();
@@ -89,7 +94,7 @@ export class UserService {
       !user.resetToken ||
       !(await bcrypt.compare(token, user.resetToken))
     ) {
-      throw new Error('Invalid or expired reset token');
+      throw new UnauthorizedException('Invalid or expired reset token');
     }
 
     const hashedPassword = await bcrypt.hash(newPassword, 10);


### PR DESCRIPTION
Closes #160

---

# 📌 Pull Request Title
FIX: Return correct HTTP status codes for auth error scenarios
## Description

Return correct HTTP status codes for auth scenarios as proper exception are thrown instead of generic exception.

## Related Issues

#160 

## Changes Made

1. Registration - Duplicate Email (409 Conflict)
Updated UserService.create() to throw ConflictException with message "An account with this email already exists"
Removed try-catch wrapper in AuthService.register() to let the exception propagate naturally
2. Forgot Password - User Not Found (404 Not Found)
Updated UserService.createResetToken() to throw NotFoundException with message "User not found"
Removed try-catch wrapper in AuthService.forgotPassword() to let the exception propagate naturally
3. Reset Password - Invalid Token (401 Unauthorized)
Updated UserService.resetPassword() to throw UnauthorizedException with message "Invalid or expired reset token"
Removed try-catch wrapper in AuthService.resetPassword() to let the exception propagate naturally
Expected Behavior
POST /auth/register with duplicate email → 409 Conflict
POST /auth/forgot-password with unknown email → 404 Not Found
POST /auth/reset-password with invalid/expired token → 401 Unauthorized

## Files Modified
auth.service.ts
users.service.ts

## Testing
API clients can now handle each error case distinctly based on proper HTTP status codes.

