### PR TITLE
fix leak data

### DIFF
--- a/backend/src/certificates/certificates.controller.spec.ts
+++ b/backend/src/certificates/certificates.controller.spec.ts
@@ -4,19 +4,44 @@ import { CertificateService } from './certificates.service';
 
 describe('CertificateController', () => {
   let controller: CertificateController;
+  let testingModule: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    testingModule = await Test.createTestingModule({
       controllers: [CertificateController],
       providers: [
-        { provide: CertificateService, useValue: { verifyCertificate: jest.fn(), getAllCertificates: jest.fn(), revokeCertificate: jest.fn() } },
+        {
+          provide: CertificateService,
+          useValue: {
+            verifyCertificate: jest.fn(),
+            getAllCertificates: jest.fn(),
+            getCertificatesByUser: jest.fn(),
+            revokeCertificate: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
-    controller = module.get<CertificateController>(CertificateController);
+    controller = testingModule.get<CertificateController>(CertificateController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getMyCertificates', () => {
+    it('should call getCertificatesByUser with the user id from the request', async () => {
+      const mockReq = { user: { id: 'user-123' } };
+      const mockCertificates = [{ id: 'cert-1' }];
+      const service = testingModule.get<CertificateService>(CertificateService);
+      (service.getCertificatesByUser as jest.Mock).mockResolvedValue(
+        mockCertificates,
+      );
+
+      const result = await controller.getMyCertificates(mockReq);
+
+      expect(service.getCertificatesByUser).toHaveBeenCalledWith('user-123');
+      expect(result).toBe(mockCertificates);
+    });
   });
 });

--- a/backend/src/certificates/certificates.controller.ts
+++ b/backend/src/certificates/certificates.controller.ts
@@ -21,7 +21,7 @@ import { VerifyCertificateDto } from './dto/verify-certificate.dto';
 
 @Controller('certificates')
 export class CertificateController {
-  constructor(private readonly certificateService: CertificateService) {}
+  constructor(private readonly certificateService: CertificateService) { }
 
   /**
    * Public endpoint to verify a certificate
@@ -42,7 +42,8 @@ export class CertificateController {
   @UseGuards(JwtAuthGuard)
   @Get()
   async getMyCertificates(@Req() req) {
-    return this.certificateService.getAllCertificates(); // optionally filter by req.user.id if needed
+    const userId = req.user.id as string;
+    return this.certificateService.getCertificatesByUser(userId);
   }
 
   /**

--- a/backend/src/certificates/certificates.service.spec.ts
+++ b/backend/src/certificates/certificates.service.spec.ts
@@ -11,7 +11,7 @@ describe('CertificateService', () => {
   let service: CertificateService;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const testingModule: TestingModule = await Test.createTestingModule({
       providers: [
         CertificateService,
         { provide: getRepositoryToken(Certificate), useValue: mockRepo() },
@@ -20,10 +20,26 @@ describe('CertificateService', () => {
       ],
     }).compile();
 
-    service = module.get<CertificateService>(CertificateService);
+    service = testingModule.get<CertificateService>(CertificateService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getCertificatesByUser', () => {
+    it('should call certificateRepository.find with user id filter', async () => {
+      const userId = 'user-123';
+      const mockCertificates = [{ id: 'cert-1' }];
+      const repo = (service as any).certificateRepository;
+      (repo.find as jest.Mock).mockResolvedValue(mockCertificates);
+
+      const result = await service.getCertificatesByUser(userId);
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { user: { id: userId } },
+      });
+      expect(result).toBe(mockCertificates);
+    });
   });
 });

--- a/backend/src/certificates/certificates.service.ts
+++ b/backend/src/certificates/certificates.service.ts
@@ -217,6 +217,12 @@ export class CertificateService {
     return this.certificateRepository.find();
   }
 
+  async getCertificatesByUser(userId: string): Promise<Certificate[]> {
+    return this.certificateRepository.find({
+      where: { user: { id: userId } },
+    });
+  }
+
   async revokeCertificate(certificateId: string): Promise<any> {
     const certificate = await this.certificateRepository.findOne({
       where: { id: certificateId },


### PR DESCRIPTION
This PR fixes a critical data privacy and authorization bug in the GET /certificates endpoint. Previously, the endpoint returned all certificates in the database to any authenticated user, instead of limiting results to the currently authenticated user.

This update ensures certificates are properly filtered by req.user.id, preventing unauthorized access to other users’ data.

Resolves #163 
