### PR TITLE
My Certificates-Learner Page

### DIFF
--- a/frontend/components/MyCertificatesPage/Certificatecard.tsx
+++ b/frontend/components/MyCertificatesPage/Certificatecard.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+    Clipboard,
+    Check,
+    ShieldCheck,
+    FileText,
+    Loader2,
+    X,
+} from "lucide-react";
+import { useCopyVerificationCode } from "@/hooks/useCopyVerificationCode";
+import { useCertificateDownload } from "@/hooks/useCertificateDownload";
+
+export interface Certificate {
+    id: string;
+    courseName: string;
+    issuedAt: string; // ISO date string
+    verificationCode: string;
+    status: "active" | "revoked";
+}
+
+interface CertificateCardProps {
+    certificate: Certificate;
+    token: string;
+}
+
+function formatDate(iso: string) {
+    return new Date(iso).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+}
+
+function truncateCode(code: string, len = 20) {
+    return code.length > len ? code.slice(0, len) + "..." : code;
+}
+
+export function CertificateCard({ certificate, token }: CertificateCardProps) {
+    const router = useRouter();
+    const { copyState, errorCode, copy } = useCopyVerificationCode();
+    const { downloadStates, download, dismissError } = useCertificateDownload();
+
+    const isRevoked = certificate.status === "revoked";
+    const dlState = downloadStates[certificate.id] ?? "idle";
+    const hasDownloadError = dlState === "error";
+
+    const handleVerify = () => {
+        router.push(`/verify-certificate/${certificate.verificationCode}`);
+    };
+
+    const handleDownload = () => {
+        if (isRevoked || dlState === "loading") return;
+        download(certificate.id, certificate.courseName, token);
+    };
+
+    return (
+        <div className="relative w-full">
+        {/* Card */}
+        <div
+            className={`
+            w-full rounded-xl bg-[#1a1a2e] border border-white/10 p-5
+            ${isRevoked ? "border-l-4 border-l-red-500" : ""}
+            `}
+        >
+            {/* Revoked badge */}
+            {isRevoked && (
+            <span className="absolute top-4 right-4 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-red-500/20 text-red-400 border border-red-500/40">
+                Revoked
+            </span>
+            )}
+
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            {/* Left: info */}
+            <div className="flex-1 min-w-0 space-y-1.5">
+                <p className="text-white font-semibold text-base leading-tight">
+                {certificate.courseName}
+                </p>
+                <p className="text-gray-400 text-xs">
+                Issued {formatDate(certificate.issuedAt)}
+                </p>
+
+                {/* Verification code row */}
+                <div className="flex items-center gap-2 mt-1">
+                <span className="font-mono text-xs text-green-400/80 truncate max-w-[200px]">
+                    {truncateCode(certificate.verificationCode)}
+                </span>
+
+                {/* Copy button */}
+                <div className="relative">
+                    <button
+                    onClick={() => copy(certificate.verificationCode)}
+                    className="p-1 rounded hover:bg-white/10 transition-colors duration-100 text-gray-400 hover:text-green-400"
+                    aria-label="Copy verification code"
+                    >
+                    {copyState === "copied" ? (
+                        <Check className="w-3.5 h-3.5 text-green-400" />
+                    ) : (
+                        <Clipboard className="w-3.5 h-3.5" />
+                    )}
+                    </button>
+
+                    {/* Error tooltip */}
+                    {copyState === "error" && errorCode && (
+                    <div className="absolute top-full left-0 mt-1 z-10 bg-gray-800 border border-white/20 rounded-md px-3 py-2 text-xs text-gray-200 whitespace-nowrap shadow-lg">
+                        Could not copy. Code:{" "}
+                        <span className="font-mono text-green-400 select-all">
+                        {errorCode}
+                        </span>
+                    </div>
+                    )}
+                </div>
+                </div>
+            </div>
+
+            {/* Right: action buttons */}
+            <div className="flex items-center gap-2 shrink-0">
+                {/* Verify button */}
+                <button
+                onClick={handleVerify}
+                className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-green-500 hover:bg-green-400 text-white text-sm font-semibold transition-colors duration-150"
+                >
+                <ShieldCheck className="w-4 h-4" />
+                {isRevoked ? "View Status" : "Verify"}
+                </button>
+
+                {/* Download button */}
+                <div className="relative flex flex-col items-end">
+                <button
+                    onClick={handleDownload}
+                    disabled={isRevoked || dlState === "loading"}
+                    title={isRevoked ? "Certificate has been revoked" : undefined}
+                    className={`
+                    flex items-center gap-1.5 px-4 py-2 rounded-lg border text-sm font-semibold transition-colors duration-150
+                    ${
+                        isRevoked
+                        ? "border-white/10 text-gray-600 cursor-not-allowed bg-transparent"
+                        : dlState === "loading"
+                        ? "border-white/20 text-gray-400 cursor-wait bg-white/5"
+                        : "border-white/20 text-gray-200 hover:bg-white/10 bg-transparent"
+                    }
+                    `}
+                >
+                    {dlState === "loading" ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                    <FileText className="w-4 h-4" />
+                    )}
+                    {dlState === "loading" ? "Preparing..." : "Download"}
+                </button>
+                </div>
+            </div>
+            </div>
+        </div>
+
+        {/* Download error message below card */}
+        {hasDownloadError && (
+            <div className="flex items-center justify-between mt-2 px-4 py-2 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+            <span>Download failed. Please try again.</span>
+            <button
+                onClick={() => dismissError(certificate.id)}
+                className="ml-3 p-0.5 rounded hover:bg-red-500/20 transition-colors"
+                aria-label="Dismiss error"
+            >
+                <X className="w-4 h-4" />
+            </button>
+            </div>
+        )}
+        </div>
+    );
+    }

--- a/frontend/components/MyCertificatesPage/Certificatecardskeleton.tsx
+++ b/frontend/components/MyCertificatesPage/Certificatecardskeleton.tsx
@@ -1,0 +1,22 @@
+export function CertificateCardSkeleton() {
+    return (
+        <div className="w-full rounded-xl bg-[#1a1a2e] border border-white/10 p-5 animate-pulse">
+        <div className="flex items-center justify-between gap-4">
+            {/* Left: text rows */}
+            <div className="flex-1 space-y-3">
+            {/* Course name */}
+            <div className="h-5 w-2/3 rounded bg-white/10" />
+            {/* Issued date */}
+            <div className="h-3.5 w-1/4 rounded bg-white/10" />
+            {/* Code row */}
+            <div className="h-4 w-1/2 rounded bg-white/10" />
+            </div>
+            {/* Right: button placeholders */}
+            <div className="flex gap-2 shrink-0">
+            <div className="h-9 w-24 rounded-lg bg-white/10" />
+            <div className="h-9 w-28 rounded-lg bg-white/10" />
+            </div>
+        </div>
+        </div>
+    );
+}

--- a/frontend/components/MyCertificatesPage/Certificatesemptystate.tsx
+++ b/frontend/components/MyCertificatesPage/Certificatesemptystate.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { GraduationCap } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export function CertificatesEmptyState() {
+    const router = useRouter();
+
+    return (
+        <div className="flex flex-col items-center justify-center flex-1 gap-4 py-20 text-center">
+        <div className="flex items-center justify-center w-20 h-20 rounded-2xl bg-green-500/10">
+            <GraduationCap className="w-10 h-10 text-green-400" />
+        </div>
+        <h2 className="text-xl font-semibold text-white">No certificates yet</h2>
+        <p className="text-sm text-gray-400 max-w-xs">
+            Complete all lessons in a course to earn your certificate.
+        </p>
+        <button
+            onClick={() => router.push("/courses")}
+            className="mt-2 px-6 py-2.5 rounded-lg bg-green-500 hover:bg-green-400 text-white font-semibold text-sm transition-colors duration-150"
+        >
+            Browse Courses
+        </button>
+        </div>
+    );
+}

--- a/frontend/components/MyCertificatesPage/Usecertificatedownload.tsx
+++ b/frontend/components/MyCertificatesPage/Usecertificatedownload.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+type DownloadState = "idle" | "loading" | "error";
+
+export function useCertificateDownload() {
+    const [downloadStates, setDownloadStates] = useState<
+        Record<string, DownloadState>
+    >({});
+    const [downloadErrors, setDownloadErrors] = useState<
+        Record<string, boolean>
+    >({});
+
+    const slugify = (name: string) =>
+        name
+        .replace(/[^a-zA-Z0-9\s]/g, "")
+        .trim()
+        .replace(/\s+/g, "-");
+
+    const download = async (
+        certificateId: string,
+        courseName: string,
+        token: string
+    ) => {
+        setDownloadStates((prev) => ({ ...prev, [certificateId]: "loading" }));
+        setDownloadErrors((prev) => ({ ...prev, [certificateId]: false }));
+
+        try {
+        const res = await fetch(`/api/certificates/${certificateId}/download`, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (!res.ok) throw new Error("Download failed");
+
+        const contentType = res.headers.get("Content-Type") || "";
+
+        if (contentType.includes("application/json")) {
+            // API returned a pre-signed URL
+            const data = await res.json();
+            window.location.href = data.url;
+        } else {
+            // API returned a blob
+            const blob = await res.blob();
+            const objectUrl = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            const slug = slugify(courseName);
+            a.href = objectUrl;
+            a.download = `Bytechain-Academy-Certificate-${slug}.pdf`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(objectUrl);
+        }
+
+        setDownloadStates((prev) => ({ ...prev, [certificateId]: "idle" }));
+        } catch {
+        setDownloadStates((prev) => ({ ...prev, [certificateId]: "error" }));
+        }
+    };
+
+    const dismissError = (certificateId: string) => {
+        setDownloadErrors((prev) => ({ ...prev, [certificateId]: false }));
+        setDownloadStates((prev) => ({ ...prev, [certificateId]: "idle" }));
+    };
+
+    return { downloadStates, downloadErrors, download, dismissError };
+}

--- a/frontend/components/MyCertificatesPage/Usecopyverificationcode.tsx
+++ b/frontend/components/MyCertificatesPage/Usecopyverificationcode.tsx
@@ -1,0 +1,36 @@
+import { useState, useRef } from "react";
+
+type CopyState = "idle" | "copied" | "error";
+
+export function useCopyVerificationCode() {
+    const [copyState, setCopyState] = useState<CopyState>("idle");
+    const [errorCode, setErrorCode] = useState<string | null>(null);
+    const revertTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const errorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const copy = async (fullCode: string) => {
+        // Clear any pending timers
+        if (revertTimer.current) clearTimeout(revertTimer.current);
+        if (errorTimer.current) clearTimeout(errorTimer.current);
+
+        try {
+        await navigator.clipboard.writeText(fullCode);
+        setCopyState("copied");
+        setErrorCode(null);
+
+        revertTimer.current = setTimeout(() => {
+            setCopyState("idle");
+        }, 2000);
+        } catch {
+        setCopyState("error");
+        setErrorCode(fullCode);
+
+        errorTimer.current = setTimeout(() => {
+            setCopyState("idle");
+            setErrorCode(null);
+        }, 4000);
+        }
+    };
+
+    return { copyState, errorCode, copy };
+}

--- a/frontend/components/MyCertificatesPage/page.tsx
+++ b/frontend/components/MyCertificatesPage/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { GraduationCap, ArrowLeft, AlertTriangle } from "lucide-react";
+import { CertificateCard, type Certificate } from "@/components/CertificateCard";
+import { CertificateCardSkeleton } from "@/components/CertificateCardSkeleton";
+import { CertificatesEmptyState } from "@/components/CertificatesEmptyState";
+
+type FetchState = "loading" | "success" | "error";
+
+function getAuthToken(): string {
+    if (typeof window === "undefined") return "";
+    return localStorage.getItem("auth_token") ?? "";
+}
+
+export default function MyCertificatesPage() {
+    const router = useRouter();
+    const [fetchState, setFetchState] = useState<FetchState>("loading");
+    const [certificates, setCertificates] = useState<Certificate[]>([]);
+    const token = getAuthToken();
+
+    const fetchCertificates = async () => {
+        setFetchState("loading");
+        try {
+        const res = await fetch("/api/users/me/certificates", {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) throw new Error("Fetch failed");
+
+        const data: Certificate[] = await res.json();
+
+        // Sort by issuedAt DESC (most recent first)
+        data.sort(
+            (a, b) =>
+            new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime()
+        );
+
+        setCertificates(data);
+        setFetchState("success");
+        } catch {
+        setFetchState("error");
+        }
+    };
+
+    useEffect(() => {
+        fetchCertificates();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleProfileBack = () => {
+        if (typeof window !== "undefined" && window.history.length > 1) {
+        router.back();
+        } else {
+        router.push("/profile");
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-[#0d0d1a] flex flex-col">
+        {/* ── Minimal nav shell ── */}
+        <nav className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+            {/* Logo */}
+            <div className="flex items-center gap-2">
+            <span className="text-green-400 font-bold text-xl tracking-tight">
+                Bytechain
+            </span>
+            <span className="text-white font-bold text-xl tracking-tight">
+                Academy
+            </span>
+            </div>
+
+            {/* ← Profile link */}
+            <button
+            onClick={handleProfileBack}
+            className="group flex items-center gap-1.5 text-sm text-gray-400 hover:text-white transition-colors duration-150"
+            aria-label="Back to profile"
+            >
+            <ArrowLeft
+                className="w-4 h-4 transition-transform duration-150 ease-in-out group-hover:-translate-x-0.5"
+                strokeWidth={2}
+            />
+            <span className="group-hover:underline underline-offset-2">
+                Profile
+            </span>
+            </button>
+        </nav>
+
+        {/* ── Page content ── */}
+        <main className="flex-1 w-full max-w-3xl mx-auto px-4 sm:px-6 py-10 flex flex-col">
+            {/* Header */}
+            <div className="flex items-center gap-4 mb-8">
+            <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-green-500/15 shrink-0">
+                <GraduationCap className="w-6 h-6 text-green-400" />
+            </div>
+            <div>
+                <h1 className="text-2xl sm:text-3xl font-bold text-white">
+                My Certificates
+                </h1>
+                <p className="text-sm text-gray-400 mt-0.5">
+                Your earned certificates from ByteChain Academy
+                </p>
+            </div>
+            </div>
+
+            {/* ── Content area ── */}
+            {fetchState === "loading" && (
+            <div className="flex flex-col gap-4">
+                <CertificateCardSkeleton />
+                <CertificateCardSkeleton />
+                <CertificateCardSkeleton />
+            </div>
+            )}
+
+            {fetchState === "error" && (
+            <div className="flex flex-col items-center justify-center flex-1 gap-4 py-20 text-center">
+                <AlertTriangle className="w-10 h-10 text-yellow-400" />
+                <p className="text-white font-semibold">
+                Could not load your certificates.
+                </p>
+                <button
+                onClick={fetchCertificates}
+                className="px-5 py-2 rounded-lg bg-green-500 hover:bg-green-400 text-white font-semibold text-sm transition-colors duration-150"
+                >
+                Try again
+                </button>
+            </div>
+            )}
+
+            {fetchState === "success" && certificates.length === 0 && (
+            <CertificatesEmptyState />
+            )}
+
+            {fetchState === "success" && certificates.length > 0 && (
+            <div className="flex flex-col gap-4">
+                {certificates.map((cert) => (
+                <CertificateCard key={cert.id} certificate={cert} token={token} />
+                ))}
+            </div>
+            )}
+        </main>
+        </div>
+    );
+}


### PR DESCRIPTION
Closes #187 

### Summary  
Implements the full **`/my-certificates` learner page** as specified in Issue #187. The page provides certificate management features including copy-to-clipboard, verification routing, downloads with error/loading states, and clear UI feedback for revoked, loading, and empty states.  

### Key Features  
* **MyCertificatesPage**:  
  - Minimal nav shell with working ← Profile link (router.back() or `/profile` fallback).  
  - Hover animation for navigation.  
* **CertificateCard**:  
  - Copy icon with 2s checkmark swap + 4s error tooltip fallback.  
  - Verify button routes to `/verify-certificate/:code`.  
  - Download button with loading/error states and human-readable filename slugification.  
  - Revoked badge with disabled download and red left-border styling.  
* **CertificateCardSkeleton**:  
  - Shimmer placeholder shown during fetch.  
* **CertificatesEmptyState**:  
  - Centered icon, heading, sub-text, and Browse Courses CTA.  
* **Hooks**:  
  - `useCopyVerificationCode`: clipboard write, icon swap state, 2s revert timer, 4s error tooltip.  
  - `useCertificateDownload`: handles blob and pre-signed URL responses, per-card loading/error state, auto-slugified filename.  
* **Sorting & Error Handling**:  
  - Certificates sorted by `issuedAt` DESC on mount.  
  - Page-level error state with “Try again” re-fetch option.  

### How to Test  
1. Navigate to `/my-certificates`.  
2. Verify certificates are sorted by `issuedAt` DESC.  
3. Test copy functionality: icon swaps to checkmark for 2s, error tooltip after 4s if failed.  
4. Click Verify → confirm routing to `/verify-certificate/:code`.  
5. Test Download → confirm loading state, filename slugification, and error handling.  
6. Check revoked certificates → badge visible, download disabled, red left-border.  
7. Simulate loading → skeleton cards appear.  
8. Simulate empty state → centered icon, heading, sub-text, and Browse Courses CTA.  
9. Trigger page-level error → confirm “Try again” re-fetch works.  

### Checklist  
- [x] Implement `MyCertificatesPage` with navigation shell  
- [x] Build `CertificateCard` with copy, verify, download, revoked states  
- [x] Add skeleton and empty state components  
- [x] Create hooks for copy and download logic  
- [x] Ensure sorting by `issuedAt` DESC  
- [x] Add page-level error handling with retry option  

--- 
