### PR TITLE
fix: add UsersModule to ProgressModule imports to resolve StreakServi…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3144,7 +3144,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
       "integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3186,6 +3186,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3202,6 +3203,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3218,6 +3220,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3234,6 +3237,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3250,6 +3254,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3266,6 +3271,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3282,6 +3288,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3298,6 +3305,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3314,6 +3322,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3330,6 +3339,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3343,7 +3353,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -3359,7 +3369,7 @@
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/backend/src/progress/progress.module.ts
+++ b/backend/src/progress/progress.module.ts
@@ -7,6 +7,8 @@ import { Lesson } from 'src/lessons/entities/lesson.entity';
 import { CertificatesModule } from 'src/certificates/certificates.module';
 import { NotificationsModule } from 'src/notifications/notifications.module';
 import { RewardsModule } from 'src/rewards/rewards.module';
+import { UsersModule } from 'src/users/users.module';
+
 
 @Module({
   imports: [
@@ -14,7 +16,9 @@ import { RewardsModule } from 'src/rewards/rewards.module';
     CertificatesModule,
     NotificationsModule,
     RewardsModule,
+    UsersModule,
   ],
+
   controllers: [ProgressController],
   providers: [ProgressService],
   exports: [ProgressService],

--- a/backend/src/progress/progress.service.spec.ts
+++ b/backend/src/progress/progress.service.spec.ts
@@ -6,6 +6,8 @@ import { Lesson } from 'src/lessons/entities/lesson.entity';
 import { CertificateService } from 'src/certificates/certificates.service';
 import { NotificationsService } from 'src/notifications/notifications.service';
 import { RewardsService } from 'src/rewards/rewards.service';
+import { StreakService } from 'src/users/streak.service';
+
 
 const makeProgressRepo = () => ({
   findOne: jest.fn(),
@@ -26,6 +28,8 @@ describe('ProgressService', () => {
   let certificateService: { issueCertificateForCourse: jest.Mock };
   let notificationsService: { createNotification: jest.Mock };
   let rewardsService: { awardXP: jest.Mock };
+  let streakService: { updateStreak: jest.Mock };
+
 
   beforeEach(async () => {
     progressRepo = makeProgressRepo();
@@ -33,6 +37,8 @@ describe('ProgressService', () => {
     certificateService = { issueCertificateForCourse: jest.fn().mockResolvedValue({}) };
     notificationsService = { createNotification: jest.fn().mockResolvedValue(undefined) };
     rewardsService = { awardXP: jest.fn().mockResolvedValue({ xp: 10, newlyAwardedBadges: [] }) };
+    streakService = { updateStreak: jest.fn().mockResolvedValue(undefined) };
+
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -42,7 +48,9 @@ describe('ProgressService', () => {
         { provide: CertificateService, useValue: certificateService },
         { provide: NotificationsService, useValue: notificationsService },
         { provide: RewardsService, useValue: rewardsService },
+        { provide: StreakService, useValue: streakService },
       ],
+
     }).compile();
 
     service = module.get<ProgressService>(ProgressService);


### PR DESCRIPTION
This PR resolves a Dependency Injection resolution error at startup caused by ProgressService injecting StreakService without the corresponding UsersModule being imported into ProgressModule.

Changes:

Added UsersModule to ProgressModule imports.
Updated progress.service.spec.ts to mock StreakService, ensuring tests pass with the new dependency.
Verified that StreakService is correctly exported in UsersModule.
Verification:

Ran npm run build successfully to ensure no DI errors at startup.
Ran npm run test -- progress.service.spec.ts and all 9 tests passed.
Closes #241 