### PR TITLE
feat(backend): enforce strong password policy and add progressive account lockout

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -23,6 +23,8 @@ describe('AuthService', () => {
     validatePassword: jest.Mock;
     createResetToken: jest.Mock;
     resetPassword: jest.Mock;
+    incrementFailedLoginAttempts: jest.Mock;
+    resetFailedLoginAttempts: jest.Mock;
   };
   let jwtService: { sign: jest.Mock };
 
@@ -33,19 +35,14 @@ describe('AuthService', () => {
       validatePassword: jest.fn(),
       createResetToken: jest.fn(),
       resetPassword: jest.fn(),
+      incrementFailedLoginAttempts: jest.fn(),
+      resetFailedLoginAttempts: jest.fn(),
     };
     jwtService = { sign: jest.fn().mockReturnValue('signed-jwt-token') };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
-        {
-          provide: UserService,
-          useValue: { create: jest.fn(), findByEmail: jest.fn() },
-        },
-        {
-          provide: JwtService,
-          useValue: { sign: jest.fn(), verify: jest.fn() },
         { provide: UserService, useValue: userService },
         { provide: JwtService, useValue: jwtService },
         { provide: ConfigService, useValue: { get: jest.fn() } },
@@ -158,6 +155,51 @@ describe('AuthService', () => {
       ).rejects.toThrow(new UnauthorizedException('Invalid credentials'));
 
       expect(jwtService.sign).not.toHaveBeenCalled();
+    });
+
+    it('should increment failed login attempts on wrong password', async () => {
+      userService.findByEmail.mockResolvedValue(mockUser);
+      userService.validatePassword.mockResolvedValue(false);
+
+      await expect(
+        service.login({ email: mockUser.email, password: 'wrong-password' }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(userService.incrementFailedLoginAttempts).toHaveBeenCalledWith(
+        mockUser.id,
+      );
+    });
+
+    it('should throw UnauthorizedException with minutes remaining when account is locked', async () => {
+      const lockedUser = {
+        ...mockUser,
+        lockedUntil: new Date(Date.now() + 15 * 60000), // 15 minutes from now
+      };
+      userService.findByEmail.mockResolvedValue(lockedUser);
+
+      await expect(
+        service.login({ email: mockUser.email, password: 'any-password' }),
+      ).rejects.toThrow(
+        new UnauthorizedException(
+          'Account is temporarily locked. Please try again in 15 minute(s).',
+        ),
+      );
+
+      expect(userService.validatePassword).not.toHaveBeenCalled();
+    });
+
+    it('should reset failed login attempts on successful login', async () => {
+      userService.findByEmail.mockResolvedValue(mockUser);
+      userService.validatePassword.mockResolvedValue(true);
+
+      await service.login({
+        email: mockUser.email,
+        password: 'correct-password',
+      });
+
+      expect(userService.resetFailedLoginAttempts).toHaveBeenCalledWith(
+        mockUser.id,
+      );
     });
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -46,18 +46,30 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    if (user.lockedUntil && user.lockedUntil > new Date()) {
+      const minutesRemaining = Math.ceil(
+        (user.lockedUntil.getTime() - Date.now()) / 60000,
+      );
+      throw new UnauthorizedException(
+        `Account is temporarily locked. Please try again in ${minutesRemaining} minute(s).`,
+      );
+    }
+
     const isPasswordValid = await this.userService.validatePassword(
       loginDto.password,
       user.password,
     );
 
     if (!isPasswordValid) {
+      await this.userService.incrementFailedLoginAttempts(user.id);
       throw new UnauthorizedException('Invalid credentials');
     }
 
     if (user.suspended) {
       throw new ForbiddenException('Your account has been suspended');
     }
+
+    await this.userService.resetFailedLoginAttempts(user.id);
 
     const token = this.generateToken(user);
 

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -4,6 +4,7 @@ import {
   MinLength,
   IsOptional,
   MaxLength,
+  Matches,
 } from 'class-validator';
 
 export class RegisterDto {
@@ -12,6 +13,9 @@ export class RegisterDto {
 
   @IsString()
   @MinLength(8)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/, {
+    message: 'Password must contain at least one lowercase letter, one uppercase letter, one digit, and one special character (@$!%*?&)',
+  })
   password: string;
 
   @IsString()

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
 
 export class ResetPasswordDto {
   @IsEmail()
@@ -9,5 +9,8 @@ export class ResetPasswordDto {
 
   @IsString()
   @MinLength(8)
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/, {
+    message: 'Password must contain at least one lowercase letter, one uppercase letter, one digit, and one special character (@$!%*?&)',
+  })
   newPassword: string;
 }

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -77,6 +77,14 @@ export class User {
   @Exclude()
   resetTokenExpires: Date | null;
 
+  @Column({ type: 'int', default: 0 })
+  @Exclude()
+  failedLoginAttempts: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  @Exclude()
+  lockedUntil: Date | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -2,22 +2,29 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { UserService } from './users.service';
 import { User } from './entities/user.entity';
+import { NotFoundException } from '@nestjs/common';
 
 describe('UserService', () => {
   let service: UserService;
+  let mockUserRepository: any;
 
   beforeEach(async () => {
+    mockUserRepository = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+      findAndCount: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserService,
         {
           provide: getRepositoryToken(User),
-          useValue: {
-            findOne: jest.fn(),
-            create: jest.fn(),
-            save: jest.fn(),
-            find: jest.fn(),
-          },
+          useValue: mockUserRepository,
         },
       ],
     }).compile();
@@ -27,5 +34,73 @@ describe('UserService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('incrementFailedLoginAttempts', () => {
+    it('should increment failed login attempts without lockout when below threshold', async () => {
+      const mockUser = {
+        id: 'user-1',
+        failedLoginAttempts: 3,
+        lockedUntil: null,
+      };
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.save.mockResolvedValue({ ...mockUser, failedLoginAttempts: 4 });
+
+      await service.incrementFailedLoginAttempts('user-1');
+
+      expect(mockUserRepository.findOne).toHaveBeenCalledWith({ where: { id: 'user-1' } });
+      expect(mockUserRepository.save).toHaveBeenCalled();
+    });
+
+    it('should set 15 minute lockout at 5 failed attempts', async () => {
+      const mockUser = {
+        id: 'user-1',
+        failedLoginAttempts: 4,
+        lockedUntil: null,
+      };
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.save.mockImplementation((user) => Promise.resolve(user));
+
+      await service.incrementFailedLoginAttempts('user-1');
+
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failedLoginAttempts: 5,
+          lockedUntil: expect.any(Date),
+        }),
+      );
+    });
+
+    it('should set 60 minute lockout at 10 failed attempts', async () => {
+      const mockUser = {
+        id: 'user-1',
+        failedLoginAttempts: 9,
+        lockedUntil: null,
+      };
+      mockUserRepository.findOne.mockResolvedValue(mockUser);
+      mockUserRepository.save.mockImplementation((user) => Promise.resolve(user));
+
+      await service.incrementFailedLoginAttempts('user-1');
+
+      expect(mockUserRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failedLoginAttempts: 10,
+          lockedUntil: expect.any(Date),
+        }),
+      );
+    });
+  });
+
+  describe('resetFailedLoginAttempts', () => {
+    it('should reset failed login attempts and lockedUntil', async () => {
+      mockUserRepository.update.mockResolvedValue(undefined);
+
+      await service.resetFailedLoginAttempts('user-1');
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith('user-1', {
+        failedLoginAttempts: 0,
+        lockedUntil: null,
+      });
+    });
   });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -368,4 +368,28 @@ export class UserService {
     user.suspended = suspended;
     return this.userRepository.save(user);
   }
+
+  async incrementFailedLoginAttempts(userId: string): Promise<void> {
+    const user = await this.getProfile(userId);
+    user.failedLoginAttempts = (user.failedLoginAttempts ?? 0) + 1;
+
+    if (user.failedLoginAttempts === 5) {
+      const lockedUntil = new Date();
+      lockedUntil.setMinutes(lockedUntil.getMinutes() + 15);
+      user.lockedUntil = lockedUntil;
+    } else if (user.failedLoginAttempts === 10) {
+      const lockedUntil = new Date();
+      lockedUntil.setMinutes(lockedUntil.getMinutes() + 60);
+      user.lockedUntil = lockedUntil;
+    }
+
+    await this.userRepository.save(user);
+  }
+
+  async resetFailedLoginAttempts(userId: string): Promise<void> {
+    await this.userRepository.update(userId, {
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+    });
+  }
 }


### PR DESCRIPTION
Closes #255

---

 
- Add password strength validation to RegisterDto and ResetPasswordDto requiring lowercase, uppercase, digit, and special character
- Add failedLoginAttempts and lockedUntil fields to User entity
- Implement progressive lockout in AuthService.login(): 15min at 5 failures, 60min at 10 failures
- Add incrementFailedLoginAttempts and resetFailedLoginAttempts methods to UserService
- Add unit tests for lockout trigger, enforcement, and reset


## Checklist

- [ ] My code follows the project's coding style.
- [ ] I have tested these changes locally.
- [ ] Documentation has been updated where necessary.
