### PR TITLE
feat(backend): add dedicated course publish and unpublish admin  endpoints with lesson count validation

### DIFF
--- a/backend/src/admin/admin-courses.controller.ts
+++ b/backend/src/admin/admin-courses.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiBearerAuth,
   ApiOperation,
   ApiQuery,
+  ApiResponse,
 } from '@nestjs/swagger';
 import { CoursesService } from '../courses/courses.service';
 import { LessonsService } from '../lessons/lessons.service';
@@ -103,5 +104,22 @@ export class AdminCoursesController {
     @Body() body: ReorderLessonsDto,
   ): Promise<void> {
     return this.lessonsService.reorderLessons(courseId, body.orderedIds);
+  }
+
+  @Patch(':id/publish')
+  @ApiOperation({ summary: 'Publish a course (admin)' })
+  @ApiResponse({ status: 200, description: 'Course published successfully', type: CourseResponseDto })
+  @ApiResponse({ status: 400, description: 'Cannot publish a course with no lessons' })
+  @ApiResponse({ status: 404, description: 'Course not found' })
+  async publish(@Param('id') id: string): Promise<CourseResponseDto> {
+    return this.coursesService.publishCourse(id);
+  }
+
+  @Patch(':id/unpublish')
+  @ApiOperation({ summary: 'Unpublish a course (admin)' })
+  @ApiResponse({ status: 200, description: 'Course unpublished successfully', type: CourseResponseDto })
+  @ApiResponse({ status: 404, description: 'Course not found' })
+  async unpublish(@Param('id') id: string): Promise<CourseResponseDto> {
+    return this.coursesService.unpublishCourse(id);
   }
 }

--- a/backend/src/courses/courses.module.ts
+++ b/backend/src/courses/courses.module.ts
@@ -9,11 +9,13 @@ import { PaginationService } from '../common/services/pagination.service';
 import { LessonsModule } from '../lessons/lessons.module';
 import { Lesson } from '../lessons/entities/lesson.entity';
 import { Progress } from '../progress/entities/progress.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Course, CourseRegistration, Lesson, Progress]),
     forwardRef(() => LessonsModule),
+    NotificationsModule,
   ],
   controllers: [CoursesController, AdminCoursesController],
   providers: [CoursesService, PaginationService],

--- a/backend/src/courses/courses.service.spec.ts
+++ b/backend/src/courses/courses.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { CoursesService } from './courses.service';
 import { Course } from './entities/course.entity';
 import { CourseRegistration } from './entities/course-registration.entity';
 import { PaginationService } from 'src/common/services/pagination.service';
 import { Lesson } from 'src/lessons/entities/lesson.entity';
 import { Progress } from 'src/progress/entities/progress.entity';
+import { NotificationsService } from 'src/notifications/notifications.service';
 
 const now = new Date();
 
@@ -46,6 +47,7 @@ describe('CoursesService', () => {
   let lessonRepo: ReturnType<typeof makeLessonRepo>;
   let progressRepo: ReturnType<typeof makeProgressRepo>;
   let paginationService: { paginate: jest.Mock };
+  let notificationsService: { createNotification: jest.Mock };
 
   beforeEach(async () => {
     courseRepo = makeCourseRepo();
@@ -55,34 +57,19 @@ describe('CoursesService', () => {
     paginationService = {
       paginate: jest.fn().mockResolvedValue(paginatedEmpty),
     };
+    notificationsService = {
+      createNotification: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CoursesService,
-        { provide: getRepositoryToken(Course), useValue: mockRepo() },
-        {
-          provide: getRepositoryToken(CourseRegistration),
-          useValue: mockRepo(),
-        },
-        { provide: getRepositoryToken(Lesson), useValue: mockRepo() },
-        { provide: getRepositoryToken(Progress), useValue: mockRepo() },
-        {
-          provide: PaginationService,
-          useValue: {
-            paginate: jest.fn().mockResolvedValue({
-              data: [],
-              total: 0,
-              page: 1,
-              limit: 10,
-              totalPages: 0,
-            }),
-          },
-        },
         { provide: getRepositoryToken(Course), useValue: courseRepo },
         { provide: getRepositoryToken(CourseRegistration), useValue: regRepo },
         { provide: getRepositoryToken(Lesson), useValue: lessonRepo },
         { provide: getRepositoryToken(Progress), useValue: progressRepo },
         { provide: PaginationService, useValue: paginationService },
+        { provide: NotificationsService, useValue: notificationsService },
       ],
     }).compile();
 
@@ -343,6 +330,101 @@ describe('CoursesService', () => {
       await service.findAllAdmin(1, 10, 'blockchain');
       const call = paginationService.paginate.mock.calls[0];
       expect(call[2].where).toBeDefined();
+    });
+  });
+
+  /* -------------------------------------------------------------------------- */
+  /*                                publishCourse                                */
+  /* -------------------------------------------------------------------------- */
+
+  describe('publishCourse', () => {
+    it('should publish a course with lessons and notify enrolled users', async () => {
+      const unpublishedCourse = { ...mockCourse, published: false };
+      courseRepo.findOne.mockResolvedValue(unpublishedCourse);
+      lessonRepo.count.mockResolvedValue(2);
+      courseRepo.save.mockResolvedValue({ ...unpublishedCourse, published: true });
+      regRepo.find.mockResolvedValue([
+        { userId: 'user-1' },
+        { userId: 'user-2' },
+      ]);
+
+      const result = await service.publishCourse(mockCourse.id);
+
+      expect(lessonRepo.count).toHaveBeenCalledWith({ where: { courseId: mockCourse.id } });
+      expect(courseRepo.save).toHaveBeenCalled();
+      expect(notificationsService.createNotification).toHaveBeenCalledTimes(2);
+      expect(notificationsService.createNotification).toHaveBeenCalledWith(
+        'user-1',
+        'NEW_CONTENT',
+        `New content available in course: ${mockCourse.title}`,
+        `/courses/${mockCourse.id}`,
+      );
+      expect(result.published).toBe(true);
+    });
+
+    it('should throw BadRequestException when course has no lessons', async () => {
+      const unpublishedCourse = { ...mockCourse, published: false };
+      courseRepo.findOne.mockResolvedValue(unpublishedCourse);
+      lessonRepo.count.mockResolvedValue(0);
+
+      await expect(service.publishCourse(mockCourse.id)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.publishCourse(mockCourse.id)).rejects.toThrow(
+        'Cannot publish a course with no lessons',
+      );
+    });
+
+    it('should return early if course is already published', async () => {
+      courseRepo.findOne.mockResolvedValue(mockCourse);
+
+      const result = await service.publishCourse(mockCourse.id);
+
+      expect(lessonRepo.count).not.toHaveBeenCalled();
+      expect(courseRepo.save).not.toHaveBeenCalled();
+      expect(result.published).toBe(true);
+    });
+
+    it('should throw NotFoundException when course does not exist', async () => {
+      courseRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.publishCourse('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  /* -------------------------------------------------------------------------- */
+  /*                              unpublishCourse                                */
+  /* -------------------------------------------------------------------------- */
+
+  describe('unpublishCourse', () => {
+    it('should unpublish a published course', async () => {
+      courseRepo.findOne.mockResolvedValue(mockCourse);
+      courseRepo.save.mockResolvedValue({ ...mockCourse, published: false });
+
+      const result = await service.unpublishCourse(mockCourse.id);
+
+      expect(courseRepo.save).toHaveBeenCalled();
+      expect(result.published).toBe(false);
+    });
+
+    it('should return early if course is already unpublished', async () => {
+      const unpublishedCourse = { ...mockCourse, published: false };
+      courseRepo.findOne.mockResolvedValue(unpublishedCourse);
+
+      const result = await service.unpublishCourse(mockCourse.id);
+
+      expect(courseRepo.save).not.toHaveBeenCalled();
+      expect(result.published).toBe(false);
+    });
+
+    it('should throw NotFoundException when course does not exist', async () => {
+      courseRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.unpublishCourse('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/backend/src/courses/courses.service.ts
+++ b/backend/src/courses/courses.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ILike, In, Repository } from 'typeorm';
 import { CourseRegistration } from '../courses/entities/course-registration.entity';
@@ -15,6 +15,8 @@ import {
   EnrollmentStatusResponseDto,
   EnrolledCourseResponseDto,
 } from './dto/enrollment-response.dto';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 
 @Injectable()
 export class CoursesService {
@@ -28,6 +30,7 @@ export class CoursesService {
     @InjectRepository(Progress)
     private progressRepository: Repository<Progress>,
     private readonly paginationService: PaginationService,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async create(createCourseDto: CreateCourseDto): Promise<CourseResponseDto> {
@@ -271,5 +274,61 @@ export class CoursesService {
       throw new NotFoundException(`Course with ID ${id} not found`);
     }
     await this.courseRepository.remove(course);
+  }
+
+  async publishCourse(id: string): Promise<CourseResponseDto> {
+    const course = await this.courseRepository.findOne({ where: { id } });
+    if (!course) {
+      throw new NotFoundException(`Course with ID ${id} not found`);
+    }
+
+    if (course.published) {
+      return new CourseResponseDto(course);
+    }
+
+    const publishedLessonCount = await this.lessonRepository.count({
+      where: { courseId: id },
+    });
+
+    if (publishedLessonCount === 0) {
+      throw new BadRequestException(
+        'Cannot publish a course with no lessons',
+      );
+    }
+
+    course.published = true;
+    const updatedCourse = await this.courseRepository.save(course);
+
+    const enrolledUsers = await this.courseRegistrationRepository.find({
+      where: { courseId: id },
+      select: ['userId'],
+    });
+
+    for (const enrollment of enrolledUsers) {
+      await this.notificationsService.createNotification(
+        enrollment.userId,
+        NotificationType.NEW_CONTENT,
+        `New content available in course: ${course.title}`,
+        `/courses/${id}`,
+      );
+    }
+
+    return new CourseResponseDto(updatedCourse);
+  }
+
+  async unpublishCourse(id: string): Promise<CourseResponseDto> {
+    const course = await this.courseRepository.findOne({ where: { id } });
+    if (!course) {
+      throw new NotFoundException(`Course with ID ${id} not found`);
+    }
+
+    if (!course.published) {
+      return new CourseResponseDto(course);
+    }
+
+    course.published = false;
+    const updatedCourse = await this.courseRepository.save(course);
+
+    return new CourseResponseDto(updatedCourse);
   }
 }


### PR DESCRIPTION
Closes #260

---

 

- Add publishCourse method to CoursesService with lesson count validation
- Add unpublishCourse method to CoursesService
- Add PATCH /admin/courses/:id/publish endpoint in AdminCoursesController
- Add PATCH /admin/courses/:id/unpublish endpoint in AdminCoursesController
- Notify enrolled students with NEW_CONTENT notification on publish
- Add Swagger decorators to both endpoints
- Add NotificationsModule to CoursesModule
- Add unit tests for publish and unpublish functionality

 
 

## Checklist

- [ ] My code follows the project's coding style.
- [ ] I have tested these changes locally.
- [ ] Documentation has been updated where necessary.
