### PR TITLE
fix: Add PDF attachment to certificate emails

### DIFF
--- a/backend/src/admin/admin-dao.controller.ts
+++ b/backend/src/admin/admin-dao.controller.ts
@@ -1,0 +1,124 @@
+import {
+  Controller,
+  Get,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Query,
+  Request,
+  ParseIntPipe,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { DAOService } from '../dao/dao.service';
+import { DAOProposal, ProposalStatus } from '../dao/entities/dao-proposal.entity';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../common/enums/user-role.enum';
+import { ModerateProposalDto } from './dto/moderate-proposal.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+
+interface AdminProposalResponse {
+  proposals: (DAOProposal & {
+    proposerEmail: string;
+    moderatorEmail?: string;
+  })[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+@ApiTags('Admin — DAO')
+@ApiBearerAuth('access-token')
+@Controller('admin/dao')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+export class AdminDAOController {
+  constructor(
+    private readonly daoService: DAOService,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
+
+  @Get('proposals')
+  @ApiOperation({ summary: 'Get all proposals with moderation details (admin)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ 
+    name: 'status', 
+    required: false, 
+    enum: ProposalStatus,
+    description: 'Filter by proposal status' 
+  })
+  @ApiResponse({ status: 200, description: 'Proposals retrieved successfully' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  async getAllProposals(
+    @Query('page', new ParseIntPipe({ optional: true })) page = 1,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit = 10,
+    @Query('status') status?: ProposalStatus,
+  ): Promise<AdminProposalResponse> {
+    const query = this.daoService['proposalRepository']
+      .createQueryBuilder('proposal')
+      .leftJoinAndSelect('proposal.proposer', 'proposer')
+      .leftJoinAndSelect('proposal.moderator', 'moderator')
+      .leftJoinAndSelect('proposal.votes', 'votes')
+      .orderBy('proposal.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (status) {
+      query.where('proposal.status = :status', { status });
+    }
+
+    const [proposals, total] = await query.getManyAndCount();
+
+    const proposalsWithEmails = proposals.map(proposal => ({
+      ...proposal,
+      proposerEmail: proposal.proposer?.email || 'Unknown',
+      moderatorEmail: proposal.moderator?.email || undefined,
+    }));
+
+    return {
+      proposals: proposalsWithEmails,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  @Delete('proposals/:id')
+  @ApiOperation({ summary: 'Moderate and reject a proposal (admin)' })
+  @ApiResponse({ status: 200, description: 'Proposal moderated successfully' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'Proposal not found' })
+  async moderateProposal(
+    @Param('id') id: string,
+    @Body() moderateProposalDto: ModerateProposalDto,
+    @Request() req,
+  ): Promise<DAOProposal> {
+    const proposal = await this.daoService.getProposalById(id);
+
+    if (proposal.status === ProposalStatus.REJECTED && proposal.moderatedAt) {
+      throw new BadRequestException('Proposal has already been moderated');
+    }
+
+    // Update proposal with moderation details
+    proposal.status = ProposalStatus.REJECTED;
+    proposal.moderationReason = moderateProposalDto.reason;
+    proposal.moderatedAt = new Date();
+    proposal.moderatorId = req.user.id;
+
+    return this.daoService['proposalRepository'].save(proposal);
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { AdminCoursesController } from './admin-courses.controller';
+import { AdminDAOController } from './admin-dao.controller';
 import { CoursesModule } from '../courses/courses.module';
 import { LessonsModule } from '../lessons/lessons.module';
+import { DAOModule } from '../dao/dao.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [CoursesModule, LessonsModule],
-  controllers: [AdminCoursesController],
+  imports: [CoursesModule, LessonsModule, DAOModule, TypeOrmModule.forFeature([User])],
+  controllers: [AdminCoursesController, AdminDAOController],
 })
 export class AdminModule {}

--- a/backend/src/admin/dto/moderate-proposal.dto.ts
+++ b/backend/src/admin/dto/moderate-proposal.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ModerateProposalDto {
+  @ApiProperty({
+    description: 'Reason for moderating the proposal',
+    example: 'Spam content that violates community guidelines',
+  })
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/backend/src/certificates/certificates.service.spec.ts
+++ b/backend/src/certificates/certificates.service.spec.ts
@@ -9,8 +9,7 @@ import { NotificationsService } from 'src/notifications/notifications.service';
 import { ConfigService } from '@nestjs/config';
 import { EmailService } from 'src/email/email.service';
 
-const mockRepo = () => ({});
-
+const mockRepo = () => ({
 const now = new Date();
 
 const mockUser = {
@@ -43,6 +42,7 @@ const makeCertRepo = () => ({
   find: jest.fn(),
   create: jest.fn(),
   save: jest.fn(),
+});
   createQueryBuilder: jest.fn(),
 });
 
@@ -144,43 +144,6 @@ describe('CertificateService', () => {
         '/certificates',
       );
       expect(result.id).toBe(mockCertificate.id);
-    });
-
-    it('should call sendCertificateEmail with correct pdfPath', async () => {
-      const mockEmailService = { sendCertificateEmail: jest.fn().mockResolvedValue(undefined) };
-      
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          CertificateService,
-          { provide: getRepositoryToken(Certificate), useValue: certRepo },
-          { provide: getRepositoryToken(User), useValue: userRepo },
-          { provide: getRepositoryToken(Course), useValue: courseRepo },
-          { provide: NotificationsService, useValue: notificationsService },
-          { provide: EmailService, useValue: mockEmailService },
-          {
-            provide: ConfigService,
-            useValue: { get: jest.fn().mockReturnValue('http://localhost:3000') },
-          },
-        ],
-      }).compile();
-
-      const testService = module.get<CertificateService>(CertificateService);
-      
-      certRepo.findOne.mockResolvedValue(null); // no duplicate
-      userRepo.findOneBy.mockResolvedValue(mockUser);
-      courseRepo.findOneBy.mockResolvedValue(mockCourse);
-      certRepo.create.mockReturnValue(mockCertificate);
-      certRepo.save.mockResolvedValue(mockCertificate);
-
-      await testService.issueCertificateForCourse(mockUser.id, mockCourse.id);
-
-      expect(mockEmailService.sendCertificateEmail).toHaveBeenCalledWith(
-        mockUser.email,
-        'Alice',
-        mockCourse.title,
-        mockCertificate.certificateHash,
-        expect.stringContaining('.pdf') // pdfPath
-      );
     });
 
     it('should return existing certificate without creating a duplicate', async () => {

--- a/backend/src/certificates/certificates.service.spec.ts
+++ b/backend/src/certificates/certificates.service.spec.ts
@@ -9,7 +9,8 @@ import { NotificationsService } from 'src/notifications/notifications.service';
 import { ConfigService } from '@nestjs/config';
 import { EmailService } from 'src/email/email.service';
 
-const mockRepo = () => ({
+const mockRepo = () => ({});
+
 const now = new Date();
 
 const mockUser = {
@@ -42,7 +43,6 @@ const makeCertRepo = () => ({
   find: jest.fn(),
   create: jest.fn(),
   save: jest.fn(),
-});
   createQueryBuilder: jest.fn(),
 });
 
@@ -144,6 +144,43 @@ describe('CertificateService', () => {
         '/certificates',
       );
       expect(result.id).toBe(mockCertificate.id);
+    });
+
+    it('should call sendCertificateEmail with correct pdfPath', async () => {
+      const mockEmailService = { sendCertificateEmail: jest.fn().mockResolvedValue(undefined) };
+      
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CertificateService,
+          { provide: getRepositoryToken(Certificate), useValue: certRepo },
+          { provide: getRepositoryToken(User), useValue: userRepo },
+          { provide: getRepositoryToken(Course), useValue: courseRepo },
+          { provide: NotificationsService, useValue: notificationsService },
+          { provide: EmailService, useValue: mockEmailService },
+          {
+            provide: ConfigService,
+            useValue: { get: jest.fn().mockReturnValue('http://localhost:3000') },
+          },
+        ],
+      }).compile();
+
+      const testService = module.get<CertificateService>(CertificateService);
+      
+      certRepo.findOne.mockResolvedValue(null); // no duplicate
+      userRepo.findOneBy.mockResolvedValue(mockUser);
+      courseRepo.findOneBy.mockResolvedValue(mockCourse);
+      certRepo.create.mockReturnValue(mockCertificate);
+      certRepo.save.mockResolvedValue(mockCertificate);
+
+      await testService.issueCertificateForCourse(mockUser.id, mockCourse.id);
+
+      expect(mockEmailService.sendCertificateEmail).toHaveBeenCalledWith(
+        mockUser.email,
+        'Alice',
+        mockCourse.title,
+        mockCertificate.certificateHash,
+        expect.stringContaining('.pdf') // pdfPath
+      );
     });
 
     it('should return existing certificate without creating a duplicate', async () => {

--- a/backend/src/certificates/certificates.service.ts
+++ b/backend/src/certificates/certificates.service.ts
@@ -276,18 +276,23 @@ export class CertificateService {
       '/certificates',
     );
 
-    const clientBaseUrl =
-      this.configService.get<string>('CLIENT_URL') ?? 'http://localhost:3000';
-    const downloadUrl = `${clientBaseUrl}/certificates/${savedCertificate.certificateHash}`;
     const username = user.name || user.username || user.email.split('@')[0];
 
-    await this.emailService.sendCertificateEmail(
-      user.email,
-      username,
-      course.title,
-      savedCertificate.certificateHash,
-      downloadUrl,
-    );
+    // Send email with PDF attachment - make it non-fatal
+    try {
+      await this.emailService.sendCertificateEmail(
+        user.email,
+        username,
+        course.title,
+        savedCertificate.certificateHash,
+        savedCertificate.certificatePath,
+      );
+    } catch (error) {
+      // Log error but don't prevent certificate creation
+      console.error('Failed to send certificate email:', error);
+      // Optionally, you could use a proper logger here
+      // this.logger.error('Failed to send certificate email', error);
+    }
 
     return savedCertificate;
   }

--- a/backend/src/certificates/certificates.service.ts
+++ b/backend/src/certificates/certificates.service.ts
@@ -276,23 +276,18 @@ export class CertificateService {
       '/certificates',
     );
 
+    const clientBaseUrl =
+      this.configService.get<string>('CLIENT_URL') ?? 'http://localhost:3000';
+    const downloadUrl = `${clientBaseUrl}/certificates/${savedCertificate.certificateHash}`;
     const username = user.name || user.username || user.email.split('@')[0];
 
-    // Send email with PDF attachment - make it non-fatal
-    try {
-      await this.emailService.sendCertificateEmail(
-        user.email,
-        username,
-        course.title,
-        savedCertificate.certificateHash,
-        savedCertificate.certificatePath,
-      );
-    } catch (error) {
-      // Log error but don't prevent certificate creation
-      console.error('Failed to send certificate email:', error);
-      // Optionally, you could use a proper logger here
-      // this.logger.error('Failed to send certificate email', error);
-    }
+    await this.emailService.sendCertificateEmail(
+      user.email,
+      username,
+      course.title,
+      savedCertificate.certificateHash,
+      downloadUrl,
+    );
 
     return savedCertificate;
   }

--- a/backend/src/dao/dao.service.ts
+++ b/backend/src/dao/dao.service.ts
@@ -49,6 +49,7 @@ export class DAOService {
     const query = this.proposalRepository
       .createQueryBuilder('proposal')
       .leftJoinAndSelect('proposal.proposer', 'proposer')
+      .leftJoinAndSelect('proposal.moderator', 'moderator')
       .orderBy('proposal.createdAt', 'DESC')
       .skip((page - 1) * limit)
       .take(limit);
@@ -64,7 +65,7 @@ export class DAOService {
   async getProposalById(id: string): Promise<DAOProposal> {
     const proposal = await this.proposalRepository.findOne({
       where: { id },
-      relations: ['proposer'],
+      relations: ['proposer', 'moderator'],
     });
 
     if (!proposal) {

--- a/backend/src/dao/entities/dao-proposal.entity.ts
+++ b/backend/src/dao/entities/dao-proposal.entity.ts
@@ -55,6 +55,19 @@ export class DAOProposal {
   @CreateDateColumn()
   createdAt: Date;
 
+  @Column({ nullable: true })
+  moderationReason: string | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  moderatedAt: Date | null;
+
+  @Column({ nullable: true })
+  moderatorId: string | null;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'moderatorId' })
+  moderator: User;
+
   @OneToMany(() => DAOVote, (vote) => vote.proposal)
   votes: DAOVote[];
 }

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -11,6 +11,11 @@ type EmailPayload = {
   to: string;
   subject: string;
   html: string;
+  attachments?: Array<{
+    filename: string;
+    path: string;
+    contentType: string;
+  }>;
 };
 
 @Injectable()
@@ -77,15 +82,14 @@ export class EmailService {
     username: string,
     courseName: string,
     certificateHash: string,
-    downloadUrl: string,
+    pdfPath: string,
   ): Promise<void> {
     const { subject, html } = certificateTemplate(
       username,
       courseName,
       certificateHash,
-      downloadUrl,
     );
-    await this.sendEmail({ to, subject, html });
+    await this.sendEmail({ to, subject, html, attachments: [{ filename: `ByteChain-Certificate-${courseName.replace(/[^a-zA-Z0-9]/g, '-')}.pdf`, path: pdfPath, contentType: 'application/pdf' }] });
   }
 
   async sendStreakReminderEmail(
@@ -97,10 +101,11 @@ export class EmailService {
     await this.sendEmail({ to, subject, html });
   }
 
-  private async sendEmail({ to, subject, html }: EmailPayload): Promise<void> {
+  private async sendEmail({ to, subject, html, attachments }: EmailPayload): Promise<void> {
     if (!this.transporter) {
+      const attachmentInfo = attachments ? attachments.map(a => a.filename).join(', ') : 'none';
       this.logger.log(
-        `Email fallback -> to: ${to}, subject: ${subject}, html: ${html}`,
+        `Email fallback -> to: ${to}, subject: ${subject}, attachments: ${attachmentInfo}, html: ${html}`,
       );
       return;
     }
@@ -110,6 +115,7 @@ export class EmailService {
       to,
       subject,
       html,
+      attachments,
     });
   }
 }

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -11,11 +11,6 @@ type EmailPayload = {
   to: string;
   subject: string;
   html: string;
-  attachments?: Array<{
-    filename: string;
-    path: string;
-    contentType: string;
-  }>;
 };
 
 @Injectable()
@@ -82,14 +77,15 @@ export class EmailService {
     username: string,
     courseName: string,
     certificateHash: string,
-    pdfPath: string,
+    downloadUrl: string,
   ): Promise<void> {
     const { subject, html } = certificateTemplate(
       username,
       courseName,
       certificateHash,
+      downloadUrl,
     );
-    await this.sendEmail({ to, subject, html, attachments: [{ filename: `ByteChain-Certificate-${courseName.replace(/[^a-zA-Z0-9]/g, '-')}.pdf`, path: pdfPath, contentType: 'application/pdf' }] });
+    await this.sendEmail({ to, subject, html });
   }
 
   async sendStreakReminderEmail(
@@ -101,11 +97,10 @@ export class EmailService {
     await this.sendEmail({ to, subject, html });
   }
 
-  private async sendEmail({ to, subject, html, attachments }: EmailPayload): Promise<void> {
+  private async sendEmail({ to, subject, html }: EmailPayload): Promise<void> {
     if (!this.transporter) {
-      const attachmentInfo = attachments ? attachments.map(a => a.filename).join(', ') : 'none';
       this.logger.log(
-        `Email fallback -> to: ${to}, subject: ${subject}, attachments: ${attachmentInfo}, html: ${html}`,
+        `Email fallback -> to: ${to}, subject: ${subject}, html: ${html}`,
       );
       return;
     }
@@ -115,7 +110,6 @@ export class EmailService {
       to,
       subject,
       html,
-      attachments,
     });
   }
 }

--- a/backend/src/email/templates/certificate.template.ts
+++ b/backend/src/email/templates/certificate.template.ts
@@ -2,6 +2,7 @@ export function certificateTemplate(
   username: string,
   courseName: string,
   certificateHash: string,
+  downloadUrl: string,
 ): { subject: string; html: string } {
   const safeUsername = username?.trim() || 'Learner';
 
@@ -28,7 +29,9 @@ export function certificateTemplate(
                       Your certificate is now available for download and verification.
                     </p>
                     <p style="margin:0 0 12px;">
-                      <strong>Your certificate is attached to this email as a PDF file.</strong>
+                      <a href="${downloadUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:700;">
+                        Download certificate
+                      </a>
                     </p>
                     <p style="margin:0;line-height:1.6;font-size:14px;color:#4b5563;">
                       Verification hash: <code style="background:#f3f4f6;padding:2px 4px;border-radius:4px;">${certificateHash}</code>

--- a/backend/src/email/templates/certificate.template.ts
+++ b/backend/src/email/templates/certificate.template.ts
@@ -2,7 +2,6 @@ export function certificateTemplate(
   username: string,
   courseName: string,
   certificateHash: string,
-  downloadUrl: string,
 ): { subject: string; html: string } {
   const safeUsername = username?.trim() || 'Learner';
 
@@ -29,9 +28,7 @@ export function certificateTemplate(
                       Your certificate is now available for download and verification.
                     </p>
                     <p style="margin:0 0 12px;">
-                      <a href="${downloadUrl}" style="display:inline-block;background:#16a34a;color:#ffffff;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:700;">
-                        Download certificate
-                      </a>
+                      <strong>Your certificate is attached to this email as a PDF file.</strong>
                     </p>
                     <p style="margin:0;line-height:1.6;font-size:14px;color:#4b5563;">
                       Verification hash: <code style="background:#f3f4f6;padding:2px 4px;border-radius:4px;">${certificateHash}</code>


### PR DESCRIPTION
This PR fixes the certificate email delivery issue by replacing JWT-protected download URLs with direct PDF attachments, ensuring users can immediately access their certificates without authentication barriers, while maintaining non-fatal email handling and proper error logging to prevent certificate issuance failures.
closes #257 