### PR TITLE
feat(backend): add class-validator decorators and Swagger ApiProperty to DAO and Currency module DTOs

### DIFF
--- a/backend/src/currencies/dto/create-currency.dto.ts
+++ b/backend/src/currencies/dto/create-currency.dto.ts
@@ -1,53 +1,177 @@
-import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, IsArray, IsUrl, ValidateNested } from 'class-validator';
+import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, IsArray, IsUrl, ValidateNested, Min, Matches } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 import { CurrencyType } from '../entities/currency-entry.entity';
 
-export class HistoricalPriceDto {
+export class HistoricalDataPointDto {
+  @ApiProperty({
+    example: '2024-01-15',
+    description: 'Date of the historical data point (YYYY-MM-DD format)'
+  })
   @IsString()
   @IsNotEmpty()
   date: string;
 
+  @ApiProperty({
+    example: 45000,
+    description: 'Price at the given date'
+  })
   @IsInt()
   price: number;
 
+  @ApiProperty({
+    example: 850000000000,
+    description: 'Market capitalization (optional)',
+    required: false
+  })
   @IsOptional()
   @IsInt()
   marketCap?: number;
 
+  @ApiProperty({
+    example: 19000000,
+    description: 'Circulating supply (optional)',
+    required: false
+  })
   @IsOptional()
   @IsInt()
   circulatingSupply?: number;
 }
 
 export class CreateCurrencyDto {
+  @ApiProperty({
+    example: 'Bitcoin',
+    description: 'Full name of the currency'
+  })
   @IsString()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({
+    example: 'BTC',
+    description: 'Currency symbol (uppercase letters only)'
+  })
   @IsString()
   @IsNotEmpty()
+  @Matches(/^[A-Z]+$/, { message: 'Symbol must contain only uppercase letters' })
   symbol: string;
 
+  @ApiProperty({
+    enum: CurrencyType,
+    example: CurrencyType.CRYPTO,
+    description: 'Type of currency: CRYPTO or FIAT'
+  })
   @IsEnum(CurrencyType)
   type: CurrencyType;
 
+  @ApiProperty({
+    example: 'Bitcoin is a decentralized digital currency that can be transferred on the peer-to-peer bitcoin network.',
+    description: 'Detailed description of the currency'
+  })
   @IsString()
   @IsNotEmpty()
   description: string;
 
+  @ApiProperty({
+    example: 'https://example.com/logo.png',
+    description: 'URL to the currency logo (optional)',
+    required: false
+  })
   @IsOptional()
   @IsUrl()
   logoUrl?: string;
 
+  @ApiProperty({
+    example: 2009,
+    description: 'Year the currency was launched (optional, minimum 1600)',
+    required: false
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1600)
+  launchYear?: number;
+
+  @ApiProperty({
+    type: [HistoricalDataPointDto],
+    description: 'Array of historical price data points (optional)',
+    required: false
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => HistoricalPriceDto)
-  historicalData?: HistoricalPriceDto[];
-
-  @IsOptional()
-  @IsInt()
-  launchYear?: number;
+  @Type(() => HistoricalDataPointDto)
+  historicalData?: HistoricalDataPointDto[];
 }
 
-export class UpdateCurrencyDto extends CreateCurrencyDto {}
+export class UpdateCurrencyDto {
+  @ApiProperty({
+    example: 'Bitcoin',
+    description: 'Full name of the currency',
+    required: false
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @ApiProperty({
+    example: 'BTC',
+    description: 'Currency symbol (uppercase letters only)',
+    required: false
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[A-Z]+$/, { message: 'Symbol must contain only uppercase letters' })
+  symbol?: string;
+
+  @ApiProperty({
+    enum: CurrencyType,
+    example: CurrencyType.CRYPTO,
+    description: 'Type of currency: CRYPTO or FIAT',
+    required: false
+  })
+  @IsOptional()
+  @IsEnum(CurrencyType)
+  type?: CurrencyType;
+
+  @ApiProperty({
+    example: 'Bitcoin is a decentralized digital currency that can be transferred on the peer-to-peer bitcoin network.',
+    description: 'Detailed description of the currency',
+    required: false
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string;
+
+  @ApiProperty({
+    example: 'https://example.com/logo.png',
+    description: 'URL to the currency logo',
+    required: false
+  })
+  @IsOptional()
+  @IsUrl()
+  logoUrl?: string;
+
+  @ApiProperty({
+    example: 2009,
+    description: 'Year the currency was launched (minimum 1600)',
+    required: false
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1600)
+  launchYear?: number;
+
+  @ApiProperty({
+    type: [HistoricalDataPointDto],
+    description: 'Array of historical price data points',
+    required: false
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => HistoricalDataPointDto)
+  historicalData?: HistoricalDataPointDto[];
+}

--- a/backend/src/dao/dto/cast-vote.dto.ts
+++ b/backend/src/dao/dto/cast-vote.dto.ts
@@ -3,7 +3,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import { VoteType } from '../entities/dao-vote.entity';
 
 export class CastVoteDto {
-  @ApiProperty({ enum: VoteType, example: VoteType.YES })
+  @ApiProperty({ 
+    enum: VoteType, 
+    example: VoteType.YES,
+    description: 'Vote type: YES, NO, or ABSTAIN'
+  })
   @IsNotEmpty()
   @IsEnum(VoteType)
   vote: VoteType;

--- a/backend/src/dao/dto/create-proposal.dto.ts
+++ b/backend/src/dao/dto/create-proposal.dto.ts
@@ -2,18 +2,23 @@ import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateProposalDto {
-  @ApiProperty({ example: 'Update Curriculum' })
-  @IsNotEmpty()
+  @ApiProperty({ 
+    example: 'Update Curriculum for Advanced Frontend Development',
+    description: 'The title of the proposal (10-200 characters)'
+  })
   @IsString()
-  @MinLength(5)
-  @MaxLength(100)
+  @IsNotEmpty()
+  @MinLength(10)
+  @MaxLength(200)
   title: string;
 
   @ApiProperty({
-    example: 'Introduce advanced React patterns to the frontend course.',
+    example: 'This proposal aims to introduce advanced React patterns including custom hooks, context optimization, and performance best practices to the frontend course. The curriculum will be updated to include real-world projects and industry-standard coding practices.',
+    description: 'The detailed description of the proposal (50-5000 characters)'
   })
-  @IsNotEmpty()
   @IsString()
-  @MinLength(20)
+  @IsNotEmpty()
+  @MinLength(50)
+  @MaxLength(5000)
   description: string;
 }


### PR DESCRIPTION

### Changes Made
- Updated `CreateProposalDto` with proper length constraints (10-200 for title, 50-5000 for description)
- Enhanced `CastVoteDto` with improved ApiProperty documentation
- Added comprehensive validators to `CreateCurrencyDto`:
  - Symbol validation with uppercase regex pattern (`@Matches(/^[A-Z]+$/)`)
  - LaunchYear minimum constraint (`@Min(1600)`)
  - Proper ApiProperty annotations for all fields
- Created proper `UpdateCurrencyDto` with all optional fields
- Renamed `HistoricalPriceDto` to `HistoricalDataPointDto` for consistency

### Acceptance Criteria Met
✅ POST /dao/proposals with empty body returns 400 with field-level errors
✅ CastVoteDto rejects values not in VoteType enum with 400
✅ CreateCurrencyDto validates all fields correctly
✅ UpdateCurrencyDto all fields optional
✅ Swagger shows correct request schemas for DAO and Currency endpoints

closes #248 