### PR TITLE
feat(backend): complete RewardsController with authenticated my-rewards and public leaderboard endpoints

### DIFF
--- a/backend/src/rewards/rewards.controller.ts
+++ b/backend/src/rewards/rewards.controller.ts
@@ -1,5 +1,12 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RewardsService } from '../rewards/rewards.service';
 
@@ -7,28 +14,124 @@ interface RequestWithUser extends Request {
   user: { id: string; email: string; role: string };
 }
 
+@ApiTags('rewards')
 @Controller('rewards')
 export class RewardsController {
   constructor(private rewardsService: RewardsService) {}
 
+  /**
+   * Returns XP, badges, and recent reward history for the authenticated user.
+   */
   @Get('my')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Get my rewards',
+    description:
+      'Returns XP total, earned badges, and recent reward history for the authenticated user.',
+  })
+  @ApiOkResponse({
+    description: 'The rewards summary for the authenticated user.',
+    schema: {
+      type: 'object',
+      properties: {
+        xp: { type: 'number', example: 250 },
+        badges: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              badge: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  key: { type: 'string' },
+                  name: { type: 'string' },
+                  description: { type: 'string' },
+                  xpThreshold: { type: 'number' },
+                  iconUrl: { type: 'string', nullable: true },
+                },
+              },
+              awardedAt: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+        recentHistory: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              amount: { type: 'number', example: 10 },
+              reason: {
+                type: 'string',
+                enum: [
+                  'LESSON_COMPLETE',
+                  'QUIZ_PASS',
+                  'COURSE_COMPLETE',
+                  'STREAK_MILESTONE',
+                ],
+              },
+              label: { type: 'string', example: 'Completed a lesson' },
+              createdAt: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
   async getMyRewards(@Req() req: RequestWithUser) {
     return this.rewardsService.getMyRewards(req.user.id);
   }
 
+  /**
+   * Returns the top 10 users on the leaderboard (public — no auth required).
+   */
   @Get('leaderboard')
+  @ApiOperation({
+    summary: 'Get leaderboard',
+    description:
+      'Returns the top 10 users ranked by XP, including their badge count. Public endpoint — no authentication required.',
+  })
+  @ApiOkResponse({
+    description: 'Top 10 leaderboard entries.',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          rank: { type: 'number', example: 1 },
+          username: { type: 'string', example: 'alice', nullable: true },
+          xp: { type: 'number', example: 500 },
+          badgesCount: { type: 'number', example: 3 },
+        },
+      },
+    },
+  })
   async getLeaderboard() {
     return this.rewardsService.getLeaderboard();
   }
 
   @Get('badges')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Get earned badges',
+    description: 'Returns all badges earned by the authenticated user.',
+  })
+  @ApiOkResponse({ description: 'List of earned badges with award dates.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
   async getEarnedBadges(@Req() req: RequestWithUser) {
     return this.rewardsService.getEarnedBadges(req.user.id);
   }
 
   @Get('milestones')
+  @ApiOperation({
+    summary: 'Get badge milestones',
+    description:
+      'Returns all available badge milestones. Public endpoint — no authentication required.',
+  })
+  @ApiOkResponse({ description: 'List of badge milestones.' })
   async getBadgeMilestones() {
     return this.rewardsService.getBadgeMilestones();
   }

--- a/backend/src/rewards/rewards.service.ts
+++ b/backend/src/rewards/rewards.service.ts
@@ -16,6 +16,14 @@ import { WebhookEvent } from 'src/webhooks/dto/create-webhook.dto';
 
 export const XP_LESSON_COMPLETE = 10;
 export const XP_QUIZ_PASS = 25;
+
+/** Human-readable labels for XP reward reasons. */
+const REASON_LABELS: Record<XpRewardReason, string> = {
+  [XpRewardReason.LESSON_COMPLETE]: 'Completed a lesson',
+  [XpRewardReason.QUIZ_PASS]: 'Passed a quiz',
+  [XpRewardReason.COURSE_COMPLETE]: 'Completed a course',
+  [XpRewardReason.STREAK_MILESTONE]: 'Streak milestone bonus',
+};
 export const XP_COURSE_COMPLETE = 100;
 
 function meetsMilestoneRule(
@@ -227,14 +235,19 @@ export class RewardsService {
   async getMyRewards(userId: string): Promise<{
     xp: number;
     badges: Array<{ badge: Badge; awardedAt: Date }>;
-    recentHistory: RewardHistory[];
+    recentHistory: Array<{
+      amount: number;
+      reason: XpRewardReason;
+      label: string;
+      createdAt: Date;
+    }>;
   }> {
     const user = await this.userRepository.findOneOrFail({
       where: { id: userId },
       select: ['xp'],
     });
 
-    const [badges, recentHistory] = await Promise.all([
+    const [badges, rawHistory] = await Promise.all([
       this.getEarnedBadges(userId),
       this.rewardHistoryRepository.find({
         where: { userId },
@@ -242,6 +255,13 @@ export class RewardsService {
         take: 50,
       }),
     ]);
+
+    const recentHistory = rawHistory.map((h) => ({
+      amount: h.amount,
+      reason: h.reason,
+      label: REASON_LABELS[h.reason] ?? h.reason,
+      createdAt: h.createdAt,
+    }));
 
     return {
       xp: user.xp,
@@ -251,17 +271,30 @@ export class RewardsService {
   }
 
   async getLeaderboard(): Promise<
-    Array<{ username: string | null; xp: number }>
+    Array<{ rank: number; username: string | null; xp: number; badgesCount: number }>
   > {
-    const rows = await this.userRepository.find({
-      select: ['username', 'name', 'xp'],
-      order: { xp: 'DESC' },
-      take: 10,
-    });
+    const rows = await this.userRepository
+      .createQueryBuilder('user')
+      .select('user.username', 'username')
+      .addSelect('user.name', 'name')
+      .addSelect('COALESCE(user.xp, 0)', 'xp')
+      .addSelect(
+        (qb) =>
+          qb
+            .select('COUNT(ub.id)')
+            .from('user_badges', 'ub')
+            .where('ub."userId" = user.id'),
+        'badgesCount',
+      )
+      .orderBy('"xp"', 'DESC')
+      .limit(10)
+      .getRawMany();
 
-    return rows.map((u) => ({
-      username: u.username ?? u.name ?? null,
-      xp: u.xp ?? 0,
+    return rows.map((r, i) => ({
+      rank: i + 1,
+      username: r.username ?? r.name ?? null,
+      xp: Number(r.xp) || 0,
+      badgesCount: Number(r.badgesCount) || 0,
     }));
   }
 }


### PR DESCRIPTION
## Summary

Completes the `RewardsController` with proper auth guards, response shapes, and Swagger documentation as specified in #251.

## Changes

### `rewards.controller.ts`
- Added `@ApiTags('rewards')` at controller level
- `GET /rewards/my`: confirmed `@UseGuards(JwtAuthGuard)`, added `@ApiBearerAuth('access-token')`, `@ApiOperation`, `@ApiOkResponse` with full schema, and `@ApiUnauthorizedResponse`
- `GET /rewards/leaderboard`: public endpoint (no guard), added `@ApiOperation` and `@ApiOkResponse` with schema including `rank`, `username`, `xp`, `badgesCount`
- `GET /rewards/badges`: added `@ApiBearerAuth`, `@ApiOperation`, `@ApiOkResponse`, `@ApiUnauthorizedResponse`
- `GET /rewards/milestones`: added `@ApiOperation`, `@ApiOkResponse`

### `rewards.service.ts`
- Added `REASON_LABELS` map to translate `XpRewardReason` enums to human-readable strings (`LESSON_COMPLETE` → "Completed a lesson", `QUIZ_PASS` → "Passed a quiz", etc.)
- `getMyRewards()`: history items now include `amount`, `reason`, `label`, and `createdAt`
- `getLeaderboard()`: replaced simple `find()` with a query builder that joins `user_badges` count via correlated subquery; returns `rank` (1-indexed), `username`, `xp`, and `badgesCount` for top 10

## Acceptance Criteria
- ✅ `GET /api/v1/rewards/my` returns `{ xp, badges, recentHistory }` for authenticated user
- ✅ Each history item has `amount`, `reason`, `label`, and `createdAt`
- ✅ `GET /api/v1/rewards/leaderboard` returns top 10 with `rank`, `username`, `xp`, `badgesCount`
- ✅ `/rewards/my` returns 401 without JWT
- ✅ `/rewards/leaderboard` accessible without authentication
- ✅ Swagger decorators on both endpoints

Closes #251 
