### PR TITLE
feat(backend): implement JWT refresh token flow with token rotation a…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,8 @@ NODE_ENV=development
 PORT=3001
 
 JWT_SECRET=change_me_to_a_random_secret_at_least_32_chars
-JWT_EXPIRES_IN=7d
+JWT_EXPIRES_IN=24h
+REFRESH_TOKEN_EXPIRES_IN=30
 
 DB_HOST=localhost
 DB_PORT=5432

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -6,6 +6,8 @@ import { RegisterDto } from './dto/register.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { LoginDto } from './dto/login.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { LogoutDto } from './dto/logout.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -22,6 +24,18 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  async refresh(@Body() refreshTokenDto: RefreshTokenDto) {
+    return this.authService.refresh(refreshTokenDto);
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  async logout(@Body() logoutDto: LogoutDto) {
+    return this.authService.logout(logoutDto);
   }
 
   @Post('forgot-password')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -9,9 +9,11 @@ import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { UsersModule } from '../users/users.module';
 import { EmailModule } from '../email/email.module';
+import { RefreshToken } from './entities/refresh-token.entity';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([RefreshToken]),
     forwardRef(() => UsersModule),
     PassportModule,
     EmailModule,
@@ -19,7 +21,9 @@ import { EmailModule } from '../email/email.module';
       imports: [ConfigModule],
       useFactory: (config: ConfigService) => ({
         secret: config.getOrThrow<string>('JWT_SECRET'),
-        signOptions: { expiresIn: '24h' },
+        signOptions: { 
+          expiresIn: config.get<string>('JWT_EXPIRES_IN') || '24h',
+        },
       }),
       inject: [ConfigService],
     }),

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,14 +5,20 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
 import { RegisterDto } from './dto/register.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { LoginDto } from './dto/login.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { LogoutDto } from './dto/logout.dto';
 <<<<<<< HEAD
 import { UserService } from '../users/users.service';
 import { EmailService } from '../email/email.service';
 import { UserRole } from '../users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
 
 @Injectable()
 export class AuthService {
@@ -21,11 +27,14 @@ export class AuthService {
     private jwtService: JwtService,
     private configService: ConfigService,
     private emailService: EmailService,
+    @InjectRepository(RefreshToken)
+    private refreshTokenRepository: Repository<RefreshToken>,
   ) {}
 
   async register(registerDto: RegisterDto) {
     const user = await this.userService.create(registerDto);
-    const token = this.generateToken(user);
+    const accessToken = this.generateToken(user);
+    const refreshToken = await this.generateRefreshToken(user.id);
     const username = user.username || user.name || user.email.split('@')[0];
 
     await this.emailService.sendWelcomeEmail(user.email, username);
@@ -36,7 +45,8 @@ export class AuthService {
         email: user.email,
         role: user.role,
       },
-      token,
+      accessToken,
+      refreshToken,
     };
   }
 
@@ -72,7 +82,8 @@ export class AuthService {
 
     await this.userService.resetFailedLoginAttempts(user.id);
 
-    const token = this.generateToken(user);
+    const accessToken = this.generateToken(user);
+    const refreshToken = await this.generateRefreshToken(user.id);
 
     return {
       user: {
@@ -80,7 +91,8 @@ export class AuthService {
         email: user.email,
         role: user.role,
       },
-      token,
+      accessToken,
+      refreshToken,
     };
   }
 
@@ -123,5 +135,81 @@ export class AuthService {
     };
 
     return this.jwtService.sign(payload);
+  }
+
+  private async generateRefreshToken(userId: string): Promise<string> {
+    const rawToken = crypto.randomBytes(40).toString('hex');
+    const hashedToken = this.hashToken(rawToken);
+    
+    const expiresInDays = parseInt(
+      this.configService.get<string>('REFRESH_TOKEN_EXPIRES_IN') || '30',
+      10,
+    );
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + expiresInDays);
+
+    await this.refreshTokenRepository.save({
+      hashedToken,
+      userId,
+      expiresAt,
+      revoked: false,
+    });
+
+    return rawToken;
+  }
+
+  private hashToken(token: string): string {
+    return crypto.createHash('sha256').update(token).digest('hex');
+  }
+
+  async refresh(refreshTokenDto: RefreshTokenDto) {
+    const hashedToken = this.hashToken(refreshTokenDto.refreshToken);
+
+    const tokenRecord = await this.refreshTokenRepository.findOne({
+      where: { hashedToken },
+      relations: ['user'],
+    });
+
+    if (!tokenRecord) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    if (tokenRecord.revoked) {
+      throw new UnauthorizedException('Refresh token has been revoked');
+    }
+
+    if (tokenRecord.expiresAt < new Date()) {
+      throw new UnauthorizedException('Refresh token has expired');
+    }
+
+    // Revoke the old token
+    tokenRecord.revoked = true;
+    await this.refreshTokenRepository.save(tokenRecord);
+
+    // Generate new tokens
+    const accessToken = this.generateToken(tokenRecord.user);
+    const newRefreshToken = await this.generateRefreshToken(tokenRecord.userId);
+
+    return {
+      accessToken,
+      refreshToken: newRefreshToken,
+    };
+  }
+
+  async logout(logoutDto: LogoutDto) {
+    const hashedToken = this.hashToken(logoutDto.refreshToken);
+
+    const tokenRecord = await this.refreshTokenRepository.findOne({
+      where: { hashedToken },
+    });
+
+    if (tokenRecord && !tokenRecord.revoked) {
+      tokenRecord.revoked = true;
+      await this.refreshTokenRepository.save(tokenRecord);
+    }
+
+    return {
+      message: 'Logged out successfully',
+    };
   }
 }

--- a/backend/src/auth/dto/logout.dto.ts
+++ b/backend/src/auth/dto/logout.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class LogoutDto {
+  @IsNotEmpty()
+  @IsString()
+  refreshToken: string;
+}

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsNotEmpty()
+  @IsString()
+  refreshToken: string;
+}

--- a/backend/src/auth/entities/refresh-token.entity.ts
+++ b/backend/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('refresh_tokens')
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  hashedToken: string;
+
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  expiresAt: Date;
+
+  @Column({ default: false })
+  revoked: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
…nd logout revocation

- Create RefreshToken entity with hashedToken, userId, expiresAt, revoked fields
- Add POST /auth/refresh endpoint for token rotation
- Add POST /auth/logout endpoint for token revocation
- Update login and register to return accessToken and refreshToken
- Implement SHA-256 token hashing for security
- Add REFRESH_TOKEN_EXPIRES_IN and JWT_EXPIRES_IN env variables
- Refresh tokens expire after 30 days, access tokens after 24 hours
- Old refresh tokens are revoked on each use (rotation)

Resolves #262