### PR TITLE
feat(frontend): implement loading skeletons and error states across all data-fetching pages

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import Link from "next/link"
 import { api } from "@/lib/api"
 import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ErrorCard } from "@/components/ui/error-card"
 
 interface Course {
   id: string
@@ -15,24 +17,46 @@ interface Course {
 export default function AdminPage() {
   const [courses, setCourses] = useState<Course[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
+  const load = useCallback(() => {
+    setLoading(true)
+    setError(null)
     api
       .get<{ data: Course[] } | Course[]>("/courses?limit=100")
       .then((res: unknown) => {
         const r = res as { data?: Course[] } | Course[]
-        const list = Array.isArray(r) ? r : r?.data ?? []
+        const list = Array.isArray(r) ? r : (r?.data ?? [])
         setCourses(list)
       })
-      .catch(() => setCourses([]))
+      .catch(() => {
+        setError("Failed to load courses. Please try again.")
+        setCourses([])
+      })
       .finally(() => setLoading(false))
   }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-6">Admin — Courses</h1>
+
       {loading ? (
-        <p className="text-gray-400">Loading courses…</p>
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Card key={i} className="border-white/10">
+              <CardContent className="p-4 flex justify-between items-center">
+                <Skeleton className="h-5 w-1/3" />
+                <Skeleton className="h-4 w-28" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : error ? (
+        <ErrorCard message={error} onRetry={load} />
       ) : courses.length === 0 ? (
         <p className="text-gray-400">No courses found.</p>
       ) : (

--- a/frontend/app/certificates/page.tsx
+++ b/frontend/app/certificates/page.tsx
@@ -9,6 +9,8 @@ import { useEffect, useState } from "react";
 import { ArrowLeft, Award, GraduationCap } from "lucide-react";
 import Link from "next/link";
 import { api } from "@/lib/api";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorCard } from "@/components/ui/error-card";
 
 interface Certificate {
   id: string;
@@ -26,22 +28,27 @@ export default function MyCertificatesPage() {
   const router = useRouter();
   const [certificates, setCertificates] = useState<Certificate[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get<Certificate[]>("/certificates");
+      setCertificates(Array.isArray(data) ? data : []);
+    } catch {
+      setError("Failed to load certificates. Please try again.");
+      setCertificates([]);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!isAuthenticated) {
       router.push("/");
       return;
     }
-    const load = async () => {
-      try {
-        const data = await api.get<Certificate[]>("/certificates");
-        setCertificates(Array.isArray(data) ? data : []);
-      } catch {
-        setCertificates([]);
-      } finally {
-        setLoading(false);
-      }
-    };
     void load();
   }, [isAuthenticated, router]);
 
@@ -74,14 +81,24 @@ export default function MyCertificatesPage() {
 
         {loading ? (
           <div className="space-y-4">
-            {[1, 2].map((i) => (
-              <div
-                key={i}
-                className="h-24 animate-pulse rounded-xl bg-white/5"
-                aria-hidden
-              />
+            {[1, 2, 3].map((i) => (
+              <Card key={i} className="border-white/10 bg-white/5">
+                <CardHeader className="flex flex-row items-start justify-between">
+                  <div className="space-y-2 flex-1">
+                    <Skeleton className="h-5 w-1/2" />
+                    <Skeleton className="h-4 w-1/4" />
+                  </div>
+                  <Skeleton className="h-6 w-16 rounded-full" />
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-8 w-32" />
+                </CardContent>
+              </Card>
             ))}
           </div>
+        ) : error ? (
+          <ErrorCard message={error} onRetry={() => void load()} />
         ) : certificates.length === 0 ? (
           <Card className="border-[#00ff88]/20 bg-gradient-to-br from-[#080e22] to-[#0a0a0a]">
             <CardContent className="flex flex-col items-center justify-center py-16">

--- a/frontend/app/courses/page.tsx
+++ b/frontend/app/courses/page.tsx
@@ -5,77 +5,35 @@ import { CourseCard } from "@/components/course-card"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft } from "lucide-react"
 import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { CourseCardSkeleton } from "@/components/courses/course-card-skeleton"
+import { ErrorCard } from "@/components/ui/error-card"
 
-const courses = [
-  {
-    id: "crypto-101",
-    title: "Crypto 101: From Fiat to Bitcoin",
-    description: "Understand why Bitcoin and blockchains exist. Learn the fundamentals of cryptocurrency and...",
-    difficulty: "Beginner" as const,
-    rating: 4.8,
-    duration: 6,
-    lessons: 8,
-    students: 1204,
-    instructor: "Dr. Sarah Johnson",
-  },
-  {
-    id: "defi-fundamentals",
-    title: "DeFi Fundamentals: Lending, AMMs & Yield",
-    description: "Walk through DeFi protocols, automated market makers, and yield farming strategies without deep...",
-    difficulty: "Intermediate" as const,
-    rating: 4.9,
-    duration: 9,
-    lessons: 12,
-    students: 856,
-    instructor: "Michael Torres",
-  },
-  {
-    id: "wallet-security",
-    title: "Wallet Security Masterclass",
-    description: "Learn how to protect your keys, avoid phishing attacks, and practice safe custody of digital assets.",
-    difficulty: "Beginner" as const,
-    rating: 4.7,
-    duration: 7,
-    lessons: 6,
-    students: 2103,
-    instructor: "Emma Rodriguez",
-  },
-  {
-    id: "smart-contracts",
-    title: "Smart Contract Development",
-    description: "Build your first smart contract with Solidity. Understand gas optimization and security patterns.",
-    difficulty: "Advanced" as const,
-    rating: 4.9,
-    duration: 15,
-    lessons: 20,
-    students: 542,
-    instructor: "David Kim",
-  },
-  {
-    id: "nft-fundamentals",
-    title: "NFT Market Fundamentals",
-    description: "Explore NFT standards, marketplaces, and digital ownership in the Web3 ecosystem.",
-    difficulty: "Intermediate" as const,
-    rating: 4.6,
-    duration: 8,
-    lessons: 10,
-    students: 945,
-    instructor: "Lisa Martinez",
-  },
-  {
-    id: "dao-governance",
-    title: "DAO Governance & Voting",
-    description: "Learn about decentralized autonomous organizations and on-chain governance mechanisms.",
-    difficulty: "Advanced" as const,
-    rating: 4.8,
-    duration: 12,
-    lessons: 15,
-    students: 387,
-    instructor: "James Wilson",
-  },
-]
+interface Course {
+  id: string
+  title: string
+  description: string
+  difficulty: "Beginner" | "Intermediate" | "Advanced"
+  rating?: number
+  duration?: number
+  lessons?: number
+  students?: number
+  enrollmentCount?: number
+  isEnrolled?: boolean
+  instructor?: string
+}
 
 export default function CoursesPage() {
+  const { data, isLoading, isError, refetch } = useQuery<Course[]>({
+    queryKey: ["courses"],
+    queryFn: async () => {
+      const res = await api.get<{ data?: Course[] } | Course[]>("/courses")
+      const r = res as { data?: Course[] } | Course[]
+      return Array.isArray(r) ? r : (r?.data ?? [])
+    },
+  })
+
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-white">
       <Header />
@@ -93,11 +51,45 @@ export default function CoursesPage() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {courses.map((course) => (
-            <CourseCard key={course.id} {...course} />
-          ))}
-        </div>
+        {isLoading && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <CourseCardSkeleton key={i} />
+            ))}
+          </div>
+        )}
+
+        {isError && (
+          <ErrorCard
+            message="Failed to load courses. Please try again."
+            onRetry={() => void refetch()}
+          />
+        )}
+
+        {!isLoading && !isError && data && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {data.length === 0 ? (
+              <p className="text-gray-400 col-span-3 text-center py-12">
+                No courses available yet.
+              </p>
+            ) : (
+              data.map((course) => (
+                <CourseCard
+                  key={course.id}
+                  id={course.id}
+                  title={course.title}
+                  description={course.description}
+                  difficulty={course.difficulty ?? "Beginner"}
+                  rating={course.rating ?? 0}
+                  duration={course.duration ?? 0}
+                  lessons={course.lessons ?? 0}
+                  students={course.enrollmentCount ?? course.students ?? 0}
+                  instructor={course.instructor ?? ""}
+                />
+              ))
+            )}
+          </div>
+        )}
       </main>
     </div>
   )

--- a/frontend/components/admin/stats-card-skeleton.tsx
+++ b/frontend/components/admin/stats-card-skeleton.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function StatsCardSkeleton() {
+  return (
+    <Card className="border-white/10 bg-white/5">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-4 w-24" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="h-8 w-16 mb-2" />
+        <Skeleton className="h-3 w-20" />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/components/atoms/skeleton.tsx
+++ b/frontend/components/atoms/skeleton.tsx
@@ -1,0 +1,2 @@
+// Re-export base Skeleton from ui/skeleton for backwards compatibility
+export { Skeleton } from "@/components/ui/skeleton"

--- a/frontend/components/courses/course-card-skeleton.tsx
+++ b/frontend/components/courses/course-card-skeleton.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { Card, CardContent, CardFooter } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function CourseCardSkeleton() {
+  return (
+    <Card className="border-white/10 bg-white/5">
+      <CardContent className="p-6 space-y-4">
+        <div className="flex justify-between items-start">
+          <Skeleton className="h-5 w-20" />
+          <Skeleton className="h-4 w-10" />
+        </div>
+        <Skeleton className="h-6 w-3/4" />
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <Skeleton className="h-4 w-1/3" />
+      </CardContent>
+      <CardFooter className="p-6 pt-0">
+        <Skeleton className="h-10 w-full" />
+      </CardFooter>
+    </Card>
+  )
+}

--- a/frontend/components/lessons/lesson-row-skeleton.tsx
+++ b/frontend/components/lessons/lesson-row-skeleton.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function LessonRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 p-4 border border-white/10 rounded-lg">
+      <Skeleton className="h-8 w-8 rounded-full flex-shrink-0" />
+      <div className="flex-1 space-y-2">
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-3 w-1/4" />
+      </div>
+      <Skeleton className="h-4 w-16" />
+    </div>
+  )
+}

--- a/frontend/components/ui/error-card.tsx
+++ b/frontend/components/ui/error-card.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { AlertCircle, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface ErrorCardProps {
+  message: string
+  onRetry?: () => void
+}
+
+export function ErrorCard({ message, onRetry }: ErrorCardProps) {
+  return (
+    <Card className="border-red-500/20 bg-red-500/5">
+      <CardContent className="flex flex-col items-center gap-4 py-8">
+        <AlertCircle className="w-8 h-8 text-red-400" />
+        <p className="text-red-400 text-center">{message}</p>
+        {onRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            className="gap-2 border-red-500/30 text-red-400 hover:bg-red-500/10"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Try again
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/components/ui/skeleton.tsx
+++ b/frontend/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded bg-white/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Summary
- Add base `Skeleton` component to `components/ui/skeleton.tsx` with `animate-pulse` and dark-theme `bg-white/10`
- Add `ErrorCard` component with `message` prop and optional `onRetry` callback with retry button
- Add page-specific skeletons: `CourseCardSkeleton`, `LessonRowSkeleton`, `StatsCardSkeleton`
- Re-export `Skeleton` from `components/atoms/skeleton.tsx` for backwards compatibility
- Replace hardcoded courses array in `app/courses/page.tsx` with TanStack Query `useQuery` + skeleton grid while loading and `ErrorCard` on error
- Apply skeleton loading states and `ErrorCard` with retry to `app/certificates/page.tsx`
- Apply skeleton loading states and `ErrorCard` with retry to `app/admin/page.tsx`
- No blank screens or unhandled promise rejections in any data-fetching page

## Test plan
- [ ] Visit `/courses` — skeleton grid (6 cards) appears while loading, real courses render on success, `ErrorCard` with retry on failure
- [ ] Visit `/certificates` — skeleton cards show while loading, `ErrorCard` with retry on error, empty state if no certs
- [ ] Visit `/admin` — skeleton rows show while loading, `ErrorCard` with retry on error
- [ ] Retry button in `ErrorCard` triggers a fresh data fetch
- [ ] All skeletons use dark-theme colours — no white flash
- [ ] No console errors or unhandled promise rejections

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)